### PR TITLE
fix: checkout repo before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,10 @@ jobs:
       - unit-tests
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/trivy-kubernetes/actions/runs/2314672244