### PR TITLE
fix: ignore namespace for cluster level resources

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -139,6 +139,15 @@ func (c *cluster) GetGVR(kind string) (schema.GroupVersionResource, error) {
 	return c.restMapper.ResourceFor(schema.GroupVersionResource{Resource: kind})
 }
 
+func IsClusterResource(gvr schema.GroupVersionResource) bool {
+	for _, r := range getClusterResources() {
+		if gvr.Resource == r {
+			return true
+		}
+	}
+	return false
+}
+
 func getClusterResources() []string {
 	return []string{
 		ClusterRoles,

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -1,0 +1,22 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsClusterResource(t *testing.T) {
+	for _, r := range getClusterResources() {
+		assert.True(t, IsClusterResource(newGVR(r)), r)
+	}
+
+	for _, r := range getNamespaceResources() {
+		assert.False(t, IsClusterResource(newGVR(r)), r)
+	}
+}
+
+func newGVR(resource string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Resource: resource}
+}

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -101,11 +101,17 @@ func (c *client) GetArtifact(ctx context.Context, kind, name string) (*artifacts
 }
 
 func (c *client) getDynamicClient(gvr schema.GroupVersionResource) dynamic.ResourceInterface {
-	k8s := c.cluster.GetDynamicClient()
+	dclient := c.cluster.GetDynamicClient()
+
+	// ignore namespace if it is a cluster level resource
+	if k8s.IsClusterResource(gvr) {
+		return dclient.Resource(gvr)
+	}
+
 	if len(c.namespace) == 0 {
-		return k8s.Resource(gvr)
+		return dclient.Resource(gvr)
 	} else {
-		return k8s.Resource(gvr).Namespace(c.namespace)
+		return dclient.Resource(gvr).Namespace(c.namespace)
 	}
 }
 

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -103,16 +103,13 @@ func (c *client) GetArtifact(ctx context.Context, kind, name string) (*artifacts
 func (c *client) getDynamicClient(gvr schema.GroupVersionResource) dynamic.ResourceInterface {
 	dclient := c.cluster.GetDynamicClient()
 
-	// ignore namespace if it is a cluster level resource
-	if k8s.IsClusterResource(gvr) {
+	// don't use namespace if it is a cluster levle resource,
+	// or namespace is empty
+	if k8s.IsClusterResource(gvr) || len(c.namespace) == 0 {
 		return dclient.Resource(gvr)
 	}
 
-	if len(c.namespace) == 0 {
-		return dclient.Resource(gvr)
-	} else {
-		return dclient.Resource(gvr).Namespace(c.namespace)
-	}
+	return dclient.Resource(gvr).Namespace(c.namespace)
 }
 
 // ignore resources to avoid duplication,


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/trivy/issues/2134

The idea is to work like `kubectl`, eg:

```
# both work
kubectl -n default get clusterroles/view
kubectl -n kube-system get clusterroles/view
```