### PR TITLE
Fix duplicate artifact

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aquasecurity/trivy-kubernetes
 go 1.18
 
 require (
+	github.com/stretchr/testify v1.7.1
 	k8s.io/apimachinery v0.23.6
 	k8s.io/cli-runtime v0.23.6
 	k8s.io/client-go v0.23.6
@@ -50,7 +51,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -124,12 +124,12 @@ func (c *cluster) GetGVRs(namespaced bool) ([]schema.GroupVersionResource, error
 	}
 
 	for _, resource := range resources {
-		list, err := c.restMapper.ResourcesFor(schema.GroupVersionResource{Resource: resource})
+		gvr, err := c.GetGVR(resource)
 		if err != nil {
 			return nil, err
 		}
 
-		grvs = append(grvs, list...)
+		grvs = append(grvs, gvr)
 	}
 
 	return grvs, nil
@@ -139,6 +139,7 @@ func (c *cluster) GetGVR(kind string) (schema.GroupVersionResource, error) {
 	return c.restMapper.ResourceFor(schema.GroupVersionResource{Resource: kind})
 }
 
+// IsClusterResource returns if a GVR is a cluster resource
 func IsClusterResource(gvr schema.GroupVersionResource) bool {
 	for _, r := range getClusterResources() {
 		if gvr.Resource == r {


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/trivy/issues/2148

The first version was checking for all GVRs of a given kind (eg: `batch/v1` and `batch/v1beta1`) to account for resources deployed on different versions.

But it is not necessary, different resources applied one in each version, will respond to both GVRs. (eg: cronjob "hello" returns for queries both in `batch/v1` and `batch/v1beta1` even though it was applied as `batch/v1beta1`, and the contrary is also true)