### PR TITLE
fix: if current namespace empty, returns default

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -88,6 +88,10 @@ func GetCluster(context string) (Cluster, error) {
 		namespace = context.Namespace
 	}
 
+	if len(namespace) == 0 {
+		namespace = "default"
+	}
+
 	restMapper, err := cf.ToRESTMapper()
 	if err != nil {
 		return nil, err

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -5,7 +5,36 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
+
+func Test_getCluster(t *testing.T) {
+	tests := []struct {
+		Name              string
+		Namespace         string
+		ExpectedNamespace string
+	}{
+		{
+			Name:              "empty context and empty namespace",
+			ExpectedNamespace: "default",
+		},
+		{
+			Name:              "non empty namespace",
+			Namespace:         "namespace",
+			ExpectedNamespace: "namespace",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			fakeConfig := createValidTestConfig(test.Namespace)
+			cluster, err := getCluster(fakeConfig, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ExpectedNamespace, cluster.GetCurrentNamespace())
+		})
+	}
+}
 
 func TestIsClusterResource(t *testing.T) {
 	for _, r := range getClusterResources() {
@@ -19,4 +48,24 @@ func TestIsClusterResource(t *testing.T) {
 
 func newGVR(resource string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{Resource: resource}
+}
+
+func createValidTestConfig(namespace string) clientcmd.ClientConfig {
+	const (
+		server = "https://anything.com:8080"
+		token  = "the-token"
+	)
+
+	config := clientcmdapi.NewConfig()
+
+	config.CurrentContext = "cluster1"
+	config.Clusters["cluster1"] = &clientcmdapi.Cluster{Server: server}
+	config.AuthInfos["cluster1"] = &clientcmdapi.AuthInfo{Token: token}
+	config.Contexts["cluster1"] = &clientcmdapi.Context{
+		Cluster:   "cluster1",
+		AuthInfo:  "cluster1",
+		Namespace: namespace,
+	}
+
+	return clientcmd.NewNonInteractiveClientConfig(*config, "cluster1", &clientcmd.ConfigOverrides{}, nil)
 }

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -17,7 +17,7 @@ func TestGetCurrentNamespace(t *testing.T) {
 		ExpectedNamespace string
 	}{
 		{
-			Name:              "empty context and empty namespace",
+			Name:              "empty namespace",
 			ExpectedNamespace: "default",
 		},
 		{


### PR DESCRIPTION
Fix https://github.com/aquasecurity/trivy/issues/2196