### PR TITLE
fix: scanning control plane resources

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
@@ -10,10 +11,14 @@ import (
 )
 
 const (
-	KindPod        = "Pod"
-	KindJob        = "Job"
-	KindCronJob    = "CronJob"
-	KindReplicaSet = "ReplicaSet"
+	KindPod                   = "Pod"
+	KindJob                   = "Job"
+	KindCronJob               = "CronJob"
+	KindReplicaSet            = "ReplicaSet"
+	KindReplicationController = "ReplicationController"
+	KindStatefulSet           = "StatefulSet"
+	KindDaemonSet             = "DaemonSet"
+	KindDeployment            = "Deployment"
 
 	Deployments            = "deployments"
 	ReplicaSets            = "replicasets"
@@ -163,6 +168,19 @@ func IsClusterResource(gvr schema.GroupVersionResource) bool {
 		}
 	}
 	return false
+}
+
+// IsBuiltInWorkload returns true if the specified v1.OwnerReference
+// is a built-in Kubernetes workload, false otherwise.
+func IsBuiltInWorkload(resource *v1.OwnerReference) bool {
+	return resource != nil &&
+		(resource.Kind == string(KindReplicaSet) ||
+			resource.Kind == string(KindReplicationController) ||
+			resource.Kind == string(KindStatefulSet) ||
+			resource.Kind == string(KindDeployment) ||
+			resource.Kind == string(KindCronJob) ||
+			resource.Kind == string(KindDaemonSet) ||
+			resource.Kind == string(KindJob))
 }
 
 func getClusterResources() []string {

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"k8s.io/client-go/dynamic"
 
 	// import auth plugins
@@ -145,10 +146,8 @@ func (c *client) ignoreResource(resource unstructured.Unstructured) bool {
 		return false
 	}
 
-	switch resource.GetKind() {
-	case k8s.KindPod, k8s.KindJob, k8s.KindReplicaSet:
-		metadata := resource.GetOwnerReferences()
-		if metadata != nil {
+	for _, owner := range resource.GetOwnerReferences() {
+		if k8s.IsBuiltInWorkload(&owner) {
 			return true
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

Fix for https://github.com/aquasecurity/trivy/issues/2588


```
$ trivy k8s -n kube-system --report summary all
34 / 34 [-------------------------------------------------------------------------------------------------------] 100.00% 1 p/s

Summary Report for minikube
┌─────────────┬──────────────────────────────────────┬─────────────────────┬────────────────────┬───────────────────┐
│  Namespace  │               Resource               │   Vulnerabilities   │ Misconfigurations  │      Secrets      │
│             │                                      ├───┬────┬───┬────┬───┼───┬───┬───┬────┬───┼───┬───┬───┬───┬───┤
│             │                                      │ C │ H  │ M │ L  │ U │ C │ H │ M │ L  │ U │ C │ H │ M │ L │ U │
├─────────────┼──────────────────────────────────────┼───┼────┼───┼────┼───┼───┼───┼───┼────┼───┼───┼───┼───┼───┼───┤
│ kube-system │ Pod/kube-apiserver-minikube          │   │ 1  │ 4 │ 19 │   │   │   │   │    │   │   │   │   │   │   │
│ kube-system │ DaemonSet/kube-proxy                 │ 6 │ 11 │ 2 │ 56 │   │   │ 2 │ 4 │ 10 │   │   │   │   │   │   │
│ kube-system │ Service/kube-dns                     │   │    │ 1 │    │   │   │   │   │    │   │   │   │   │   │   │
│ kube-system │ Pod/etcd-minikube                    │   │ 12 │ 4 │    │   │   │ 1 │ 3 │ 7  │   │   │   │   │   │   │
│ kube-system │ Pod/kube-controller-manager-minikube │   │ 1  │ 3 │ 11 │   │   │   │   │    │   │   │   │   │   │   │
│ kube-system │ Pod/kube-scheduler-minikube          │   │ 1  │ 3 │ 9  │   │   │   │   │    │   │   │   │   │   │   │
│ kube-system │ Deployment/coredns                   │   │ 4  │ 1 │    │   │   │   │ 3 │ 5  │   │   │   │   │   │   │
│ kube-system │ Pod/storage-provisioner              │   │ 6  │ 2 │    │   │   │ 1 │ 5 │ 10 │   │   │   │   │   │   │
└─────────────┴──────────────────────────────────────┴───┴────┴───┴────┴───┴───┴───┴───┴────┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```