### PR TITLE
fix: remove support to PodSecurityPolicies

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -38,7 +38,6 @@ const (
 	LimitRanges            = "limitranges"
 	ClusterRoles           = "clusterroles"
 	ClusterRoleBindings    = "clusterrolebindings"
-	PodSecurityPolicies    = "podsecuritypolicies"
 )
 
 // Cluster interface represents the operations needed to scan a cluster
@@ -203,7 +202,6 @@ func getClusterResources() []string {
 	return []string{
 		ClusterRoles,
 		ClusterRoleBindings,
-		PodSecurityPolicies,
 	}
 }
 


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/trivy/issues/3063

This is a quick fix to avoid having `trivy k8s cluster` broken for newer kubernetes. I'll create two issues for we to discuss for the next release:

1 - should we support PSP for old clusters? 
2 - add support for PolicySecurityStanard, which is replacing PSP
