### PR TITLE
Add support for Node Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 coverage.txt
 
 dist/
+vendor/
+.vscode/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -40,6 +40,14 @@
     <property name="go.vendoring.notification.had.been.shown" value="true" />
     <property name="vue.rearranger.settings.migration" value="true" />
   </component>
+  <component name="RunManager">
+    <configuration default="true" type="OPA_RUN_CONFIGURATION" factoryName="Opa configuration factory">
+      <option name="query" value="" />
+      <option name="additionalargs" value="" />
+      <envs />
+      <method v="2" />
+    </configuration>
+  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="f7712d25-f476-4db0-b49c-f4143deb94f4" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/pkg/jobs/collector.go" beforeDir="false" afterPath="$PROJECT_DIR$/pkg/jobs/collector.go" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="GOROOT" url="file:///opt/homebrew/Cellar/go/1.19.1/libexec" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GoLibraries">
+    <option name="indexEntireGoPath" value="false" />
+  </component>
+  <component name="KubernetesApiPersistence">
+    <option name="context" value="kind-kind" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2JomimF2LWytIWfXeC2rvoEX5DA" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="go.formatter.settings.were.checked" value="true" />
+    <property name="go.import.settings.migrated" value="true" />
+    <property name="go.sdk.automatically.set" value="true" />
+    <property name="go.vendoring.notification.had.been.shown" value="true" />
+    <property name="vue.rearranger.settings.migration" value="true" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="f7712d25-f476-4db0-b49c-f4143deb94f4" name="Changes" comment="" />
+      <created>1672752944527</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1672752944527</updated>
+      <workItem from="1672752946136" duration="3958000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VgoProject">
+    <integration-enabled>true</integration-enabled>
+  </component>
+</project>

--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
-	"github.com/aquasecurity/trivy-kubernetes/pkg/jobs"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/trivyk8s"
 	"go.uber.org/zap"
@@ -37,51 +36,52 @@ func main() {
 		log.Fatal(err)
 	}
 	printArtifacts(artifacts)
-
-	fmt.Println("Scanning namespace 'default'")
-	//trivy k8s --namespace default
-	artifacts, err = trivyk8s.Namespace("default").ListArtifacts(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	printArtifacts(artifacts)
-
-	fmt.Println("Scanning namespace 'default', resource 'deployment/orion'")
-
-	//trivy k8s --namespace default deployment/orion
-	artifact, err := trivyk8s.Namespace("default").GetArtifact(ctx, "deploy", "orion")
-	if err != nil {
-		log.Fatal(err)
-	}
-	printArtifact(artifact)
-
-	fmt.Println("Scanning 'deployments'")
-
-	//trivy k8s deployment
-	artifacts, err = trivyk8s.Namespace("default").Resources("deployment").ListArtifacts(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	printArtifacts(artifacts)
-
-	fmt.Println("Scanning 'cm,pods'")
-	//trivy k8s clusterroles,pods
-	artifacts, err = trivyk8s.Namespace("default").Resources("cm,pods").ListArtifacts(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	printArtifacts(artifacts)
-	// collect node info
-	for _, resource := range artifacts {
-		if resource.Kind != "Node" {
-			continue
-		}
-		jc := jobs.NewCollector(cluster)
-		output, err := jc.ApplyAndCollect(ctx, "node-collector", resource.Name)
+	/*
+		fmt.Println("Scanning namespace 'default'")
+		//trivy k8s --namespace default
+		artifacts, err = trivyk8s.Namespace("default").ListArtifacts(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println(output)
+		printArtifacts(artifacts)
+
+		fmt.Println("Scanning namespace 'default', resource 'deployment/orion'")
+
+		//trivy k8s --namespace default deployment/orion
+		artifact, err := trivyk8s.Namespace("default").GetArtifact(ctx, "deploy", "orion")
+		if err != nil {
+			log.Fatal(err)
+		}
+		printArtifact(artifact)
+
+		fmt.Println("Scanning 'deployments'")
+
+		//trivy k8s deployment
+		artifacts, err = trivyk8s.Namespace("default").Resources("deployment").ListArtifacts(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		printArtifacts(artifacts)
+
+		fmt.Println("Scanning 'cm,pods'")
+		//trivy k8s clusterroles,pods
+		artifacts, err = trivyk8s.Namespace("default").Resources("cm,pods").ListArtifacts(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		printArtifacts(artifacts)
+	*/
+	// collect node info
+
+	ar, err := trivyk8s.ListArtifactAndNodeInfo(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, a := range ar {
+		if a.Kind != "NodeInfo" {
+			continue
+		}
+		fmt.Println(a.RawResource)
 	}
 }
 

--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -36,41 +36,41 @@ func main() {
 		log.Fatal(err)
 	}
 	printArtifacts(artifacts)
-	/*
-		fmt.Println("Scanning namespace 'default'")
-		//trivy k8s --namespace default
-		artifacts, err = trivyk8s.Namespace("default").ListArtifacts(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
-		printArtifacts(artifacts)
 
-		fmt.Println("Scanning namespace 'default', resource 'deployment/orion'")
+	fmt.Println("Scanning namespace 'default'")
+	//trivy k8s --namespace default
+	artifacts, err = trivyk8s.Namespace("default").ListArtifacts(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	printArtifacts(artifacts)
 
-		//trivy k8s --namespace default deployment/orion
-		artifact, err := trivyk8s.Namespace("default").GetArtifact(ctx, "deploy", "orion")
-		if err != nil {
-			log.Fatal(err)
-		}
-		printArtifact(artifact)
+	fmt.Println("Scanning namespace 'default', resource 'deployment/orion'")
 
-		fmt.Println("Scanning 'deployments'")
+	//trivy k8s --namespace default deployment/orion
+	artifact, err := trivyk8s.Namespace("default").GetArtifact(ctx, "deploy", "orion")
+	if err != nil {
+		log.Fatal(err)
+	}
+	printArtifact(artifact)
 
-		//trivy k8s deployment
-		artifacts, err = trivyk8s.Namespace("default").Resources("deployment").ListArtifacts(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
-		printArtifacts(artifacts)
+	fmt.Println("Scanning 'deployments'")
 
-		fmt.Println("Scanning 'cm,pods'")
-		//trivy k8s clusterroles,pods
-		artifacts, err = trivyk8s.Namespace("default").Resources("cm,pods").ListArtifacts(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
-		printArtifacts(artifacts)
-	*/
+	//trivy k8s deployment
+	artifacts, err = trivyk8s.Namespace("default").Resources("deployment").ListArtifacts(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	printArtifacts(artifacts)
+
+	fmt.Println("Scanning 'cm,pods'")
+	//trivy k8s clusterroles,pods
+	artifacts, err = trivyk8s.Namespace("default").Resources("cm,pods").ListArtifacts(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	printArtifacts(artifacts)
+
 	// collect node info
 
 	ar, err := trivyk8s.ListArtifactAndNodeInfo(ctx)

--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -39,7 +39,6 @@ func main() {
 	printArtifacts(artifacts)
 
 	fmt.Println("Scanning namespace 'default'")
-
 	//trivy k8s --namespace default
 	artifacts, err = trivyk8s.Namespace("default").ListArtifacts(ctx)
 	if err != nil {
@@ -72,14 +71,13 @@ func main() {
 		log.Fatal(err)
 	}
 	printArtifacts(artifacts)
-
 	// collect node info
 	for _, resource := range artifacts {
 		if resource.Kind != "Node" {
 			continue
 		}
 		jc := jobs.NewCollector(cluster)
-		output, err := jc.ApplyAndCollect(ctx, "node-collector", resource.Name, "default")
+		output, err := jc.ApplyAndCollect(ctx, "node-collector", resource.Name)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
+	"github.com/aquasecurity/trivy-kubernetes/pkg/jobs"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/trivyk8s"
 	"go.uber.org/zap"
@@ -71,6 +72,19 @@ func main() {
 		log.Fatal(err)
 	}
 	printArtifacts(artifacts)
+
+	// collect node info
+	for _, resource := range artifacts {
+		if resource.Kind != "Node" {
+			continue
+		}
+		jc := jobs.NewCollector(cluster)
+		output, err := jc.ApplyAndCollect(ctx, "node-collector", resource.Name, "default")
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(output)
+	}
 }
 
 func printArtifacts(artifacts []*artifacts.Artifact) {

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,15 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
+	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/cli-runtime v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/klog/v2 v2.80.1
 	k8s.io/kubectl v0.26.1
+	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -59,14 +64,9 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.1 // indirect
-	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
+github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/artifacts/artifacts_test.go
+++ b/pkg/artifacts/artifacts_test.go
@@ -1,8 +1,8 @@
 package artifacts
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,7 +49,7 @@ func TestFromResource(t *testing.T) {
 func resourceFromFile(fixture string) unstructured.Unstructured {
 	fixture = filepath.Join("testdata", "fixtures", fixture)
 
-	content, err := ioutil.ReadFile(fixture)
+	content, err := os.ReadFile(fixture)
 	if err != nil {
 		log.Fatalf("error reading fixture: %v", err)
 	}

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -1,0 +1,58 @@
+package jobs
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type JobOption func(*JobBuilder)
+
+func WithTemplate(template string) JobOption {
+	return func(j *JobBuilder) {
+		j.template = template
+	}
+}
+
+func WithNodeSelector(nodeSelector string) JobOption {
+	return func(j *JobBuilder) {
+		j.nodeSelector = nodeSelector
+	}
+}
+func WithNamespace(namespace string) JobOption {
+	return func(j *JobBuilder) {
+		j.namespace = namespace
+	}
+}
+
+func GetJob(opts ...JobOption) (*batchv1.Job, error) {
+	jb := &JobBuilder{}
+	for _, opt := range opts {
+		opt(jb)
+	}
+	return jb.build()
+}
+
+type JobBuilder struct {
+	template     string
+	nodeSelector string
+	namespace    string
+}
+
+func (b *JobBuilder) build() (*batchv1.Job, error) {
+	template := getTemplate(b.template)
+	var job batchv1.Job
+
+	err := yaml.Unmarshal([]byte(template), &job)
+	if err != nil {
+		return nil, err
+	}
+	if len(b.namespace) > 0 {
+		job.Namespace = b.namespace
+	} else {
+		job.Namespace = "default"
+	}
+	if len(b.nodeSelector) > 0 {
+		job.Spec.Template.Spec.NodeName = b.nodeSelector
+	}
+	return &job, nil
+}

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -76,10 +76,16 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 	}
 	// append lables
 	for key, val := range b.labels {
+		if job.Labels == nil {
+			job.Labels = make(map[string]string)
+		}
 		job.Labels[key] = val
 	}
 	// append annotation
 	for key, val := range b.annotations {
+		if job.Annotations == nil {
+			job.Annotations = make(map[string]string)
+		}
 		job.Annotations[key] = val
 	}
 

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -65,7 +65,14 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 	if len(b.nodeSelector) > 0 {
 		job.Spec.Template.Spec.NodeName = b.nodeSelector
 	}
-	job.Labels = b.labels
-	job.Annotations = b.annotations
+	// append lables
+	for key, val := range b.labels {
+		job.Labels[key] = val
+	}
+	// append annotation
+	for key, val := range b.annotations {
+		job.Annotations[key] = val
+	}
+
 	return &job, nil
 }

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -30,6 +30,12 @@ func WithLabels(labels map[string]string) JobOption {
 	}
 }
 
+func WithAnnotation(annotations map[string]string) JobOption {
+	return func(j *JobBuilder) {
+		j.annotations = annotations
+	}
+}
+
 func GetJob(opts ...JobOption) (*batchv1.Job, error) {
 	jb := &JobBuilder{}
 	for _, opt := range opts {
@@ -43,6 +49,7 @@ type JobBuilder struct {
 	nodeSelector string
 	namespace    string
 	labels       map[string]string
+	annotations  map[string]string
 }
 
 func (b *JobBuilder) build() (*batchv1.Job, error) {
@@ -59,5 +66,6 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 		job.Spec.Template.Spec.NodeName = b.nodeSelector
 	}
 	job.Labels = b.labels
+	job.Annotations = b.annotations
 	return &job, nil
 }

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -29,6 +29,12 @@ func WithNamespace(namespace string) JobOption {
 	}
 }
 
+func WithJobServiceAccount(sa string) JobOption {
+	return func(j *JobBuilder) {
+		j.serviceAccount = sa
+	}
+}
+
 func WithLabels(labels map[string]string) JobOption {
 	return func(j *JobBuilder) {
 		j.labels = labels
@@ -50,12 +56,13 @@ func GetJob(opts ...JobOption) (*batchv1.Job, error) {
 }
 
 type JobBuilder struct {
-	template     string
-	nodeSelector string
-	namespace    string
-	name         string
-	labels       map[string]string
-	annotations  map[string]string
+	template       string
+	nodeSelector   string
+	namespace      string
+	serviceAccount string
+	name           string
+	labels         map[string]string
+	annotations    map[string]string
 }
 
 func (b *JobBuilder) build() (*batchv1.Job, error) {
@@ -87,6 +94,9 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 			job.Annotations = make(map[string]string)
 		}
 		job.Annotations[key] = val
+	}
+	if len(b.serviceAccount) > 0 {
+		job.Spec.Template.Spec.ServiceAccountName = b.serviceAccount
 	}
 
 	return &job, nil

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -18,6 +18,11 @@ func WithNodeSelector(nodeSelector string) JobOption {
 		j.nodeSelector = nodeSelector
 	}
 }
+func WithJobName(name string) JobOption {
+	return func(j *JobBuilder) {
+		j.name = name
+	}
+}
 func WithNamespace(namespace string) JobOption {
 	return func(j *JobBuilder) {
 		j.namespace = namespace
@@ -48,6 +53,7 @@ type JobBuilder struct {
 	template     string
 	nodeSelector string
 	namespace    string
+	name         string
 	labels       map[string]string
 	annotations  map[string]string
 }
@@ -61,6 +67,9 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 		return nil, err
 	}
 	job.Namespace = b.namespace
+	if len(b.name) > 0 {
+		job.Name = b.name
+	}
 
 	if len(b.nodeSelector) > 0 {
 		job.Spec.Template.Spec.NodeName = b.nodeSelector

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -24,6 +24,12 @@ func WithNamespace(namespace string) JobOption {
 	}
 }
 
+func WithLabels(labels map[string]string) JobOption {
+	return func(j *JobBuilder) {
+		j.labels = labels
+	}
+}
+
 func GetJob(opts ...JobOption) (*batchv1.Job, error) {
 	jb := &JobBuilder{}
 	for _, opt := range opts {
@@ -36,6 +42,7 @@ type JobBuilder struct {
 	template     string
 	nodeSelector string
 	namespace    string
+	labels       map[string]string
 }
 
 func (b *JobBuilder) build() (*batchv1.Job, error) {
@@ -51,5 +58,6 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 	if len(b.nodeSelector) > 0 {
 		job.Spec.Template.Spec.NodeName = b.nodeSelector
 	}
+	job.Labels = b.labels
 	return &job, nil
 }

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -46,11 +46,8 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(b.namespace) > 0 {
-		job.Namespace = b.namespace
-	} else {
-		job.Namespace = "default"
-	}
+	job.Namespace = b.namespace
+
 	if len(b.nodeSelector) > 0 {
 		job.Spec.Template.Spec.NodeName = b.nodeSelector
 	}

--- a/pkg/jobs/builder_test.go
+++ b/pkg/jobs/builder_test.go
@@ -32,7 +32,7 @@ func TestLoadBuilder(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:    "node-collector",
-									Image:   "ghcr.io/aquasecurity/node-collector:0.0.3",
+									Image:   "ghcr.io/aquasecurity/node-collector:0.0.4",
 									Command: []string{"node-collector"},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/pkg/jobs/builder_test.go
+++ b/pkg/jobs/builder_test.go
@@ -32,7 +32,7 @@ func TestLoadBuilder(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:    "node-collector",
-									Image:   "ghcr.io/aquasecurity/node-collector:0.0.4",
+									Image:   "ghcr.io/aquasecurity/node-collector:0.0.5",
 									Command: []string{"node-collector"},
 									VolumeMounts: []corev1.VolumeMount{
 										{

--- a/pkg/jobs/builder_test.go
+++ b/pkg/jobs/builder_test.go
@@ -23,7 +23,7 @@ func TestLoadBuilder(t *testing.T) {
 					Kind:       "Job",
 					APIVersion: "batch/v1",
 				},
-				ObjectMeta: v1.ObjectMeta{Name: "node-collector", Namespace: "default"},
+				ObjectMeta: v1.ObjectMeta{Name: "node-collector"},
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: v1.ObjectMeta{Labels: map[string]string{"app": "node-collector"}},

--- a/pkg/jobs/builder_test.go
+++ b/pkg/jobs/builder_test.go
@@ -1,0 +1,157 @@
+package jobs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLoadBuilder(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateName string
+		wantJob      *batchv1.Job
+	}{
+		{name: "node-collector job",
+			templateName: "node-collector",
+			wantJob: &batchv1.Job{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Job",
+					APIVersion: "batch/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{Name: "node-collector", Namespace: "default"},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{Labels: map[string]string{"app": "node-collector"}},
+						Spec: corev1.PodSpec{
+							HostPID: true,
+							Containers: []corev1.Container{
+								{
+									Name:    "node-collector",
+									Image:   "ghcr.io/aquasecurity/node-collector:0.0.3",
+									Command: []string{"node-collector"},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "var-lib-etcd",
+											MountPath: "/var/lib/etcd",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "var-lib-kubelet",
+											MountPath: "/var/lib/kubelet",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "var-lib-kube-scheduler",
+											MountPath: "/var/lib/kube-scheduler",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "var-lib-kube-controller-manager",
+											MountPath: "/var/lib/kube-controller-manager",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "etc-systemd",
+											MountPath: "/etc/systemd",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "lib-systemd",
+											MountPath: "/lib/systemd/",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "srv-kubernetes",
+											MountPath: "/srv/kubernetes/",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "etc-kubernetes",
+											MountPath: "/etc/kubernetes",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "usr-bin",
+											MountPath: "/usr/local/mount-from-host/bin",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "etc-cni-netd",
+											MountPath: "/etc/cni/net.d/",
+											ReadOnly:  true,
+										},
+										{
+											Name:      "opt-cni-bin",
+											MountPath: "/opt/cni/bin/",
+											ReadOnly:  true,
+										},
+									},
+								},
+							},
+							RestartPolicy: "Never",
+							Volumes: []corev1.Volume{
+								{
+									Name:         "var-lib-etcd",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/etcd"}},
+								},
+								{
+									Name:         "var-lib-kubelet",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/kubelet"}},
+								},
+								{
+									Name:         "var-lib-kube-scheduler",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/kube-scheduler"}},
+								},
+								{
+									Name:         "var-lib-kube-controller-manager",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/kube-controller-manager"}},
+								},
+								{
+									Name:         "etc-systemd",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/etc/systemd"}},
+								},
+								{
+									Name:         "lib-systemd",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/lib/systemd"}},
+								},
+								{
+									Name:         "srv-kubernetes",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/srv/kubernetes"}},
+								},
+								{
+									Name:         "etc-kubernetes",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/etc/kubernetes"}},
+								},
+								{
+									Name:         "usr-bin",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/usr/bin"}},
+								},
+								{
+									Name:         "etc-cni-netd",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/etc/cni/net.d/"}},
+								},
+								{
+									Name:         "opt-cni-bin",
+									VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/opt/cni/bin/"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotJob, err := GetJob(WithTemplate(tt.templateName))
+			assert.NoError(t, err)
+			assert.True(t, reflect.DeepEqual(gotJob, tt.wantJob))
+		})
+	}
+}

--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -16,6 +16,8 @@ import (
 const (
 	NodeCollectorName  = "node-collector"
 	TrivyNamespace     = "trivy"
+
+	// job headers
 	TrivyCollectorName = "trivy.collector.name"
 	TrivyAutoCreated   = "trivy.automatic.created"
 	TrivyResourceName  = "trivy.resource.name"

--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -33,6 +33,7 @@ type jobCollector struct {
 	annotation   map[string]string
 	templateName string
 	namespace    string
+	name         string
 }
 
 type CollectorOption func(*jobCollector)
@@ -58,6 +59,12 @@ func WithJoAnnotation(annotation map[string]string) CollectorOption {
 func WithJobNamespace(namespace string) CollectorOption {
 	return func(jc *jobCollector) {
 		jc.namespace = namespace
+	}
+}
+
+func WithName(name string) CollectorOption {
+	return func(jc *jobCollector) {
+		jc.name = name
 	}
 }
 
@@ -89,7 +96,7 @@ func (jb *jobCollector) ApplyAndCollect(ctx context.Context, nodeName string) (s
 		WithTemplate(jb.templateName),
 		WithNodeSelector(nodeName),
 		WithNamespace(TrivyNamespace),
-		WithJobName(fmt.Sprintf("%s-%s", jb.templateName, nodeName)))
+		WithJobName(jb.name))
 	if err != nil {
 		return "", fmt.Errorf("running node-collector job: %w", err)
 	}

--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -96,7 +96,7 @@ func (jb *jobCollector) ApplyAndCollect(ctx context.Context, nodeName string) (s
 		WithTemplate(jb.templateName),
 		WithNodeSelector(nodeName),
 		WithNamespace(TrivyNamespace),
-		WithJobName(jb.name))
+		WithJobName(fmt.Sprintf("%s-%s", jb.templateName, nodeName)))
 	if err != nil {
 		return "", fmt.Errorf("running node-collector job: %w", err)
 	}
@@ -144,7 +144,7 @@ func (jb *jobCollector) Apply(ctx context.Context, nodeName string) (*batchv1.Jo
 		WithLabels(jb.labels),
 		WithAnnotation(jb.annotation),
 		WithTemplate(jb.templateName),
-		WithJobName(fmt.Sprintf("%s-%s", jb.templateName, nodeName)),
+		WithJobName(jb.name),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running node-collector job: %w", err)

--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -137,6 +137,7 @@ func (jb *jobCollector) Apply(ctx context.Context, nodeName string) (*batchv1.Jo
 		WithLabels(jb.labels),
 		WithAnnotation(jb.annotation),
 		WithTemplate(jb.templateName),
+		WithJobName(fmt.Sprintf("%s-%s", jb.templateName, nodeName)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running node-collector job: %w", err)

--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -1,0 +1,82 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	containerName = "node-collector"
+)
+
+type Collector interface {
+	ApplyAndCollect(ctx context.Context, templateName string, nodeName string, namespace string) (string, error)
+	Apply(ctx context.Context, templateName string, nodeName string, namespace string) (*batchv1.Job, error)
+}
+
+type jobCollector struct {
+	cluster    k8s.Cluster
+	logsReader LogsReader
+}
+
+func NewCollector(
+	cluster k8s.Cluster,
+) Collector {
+	return &jobCollector{
+		cluster:    cluster,
+		logsReader: NewLogsReader(cluster.GetK8sClientSet()),
+	}
+}
+
+// ApplyAndCollect deploy k8s job by template to  specific node  and namespace, it read pod logs
+// cleaning up job and returning it output
+func (jb *jobCollector) ApplyAndCollect(ctx context.Context, templateName string, nodeName string, namespace string) (string, error) {
+	job, err := GetJob(WithTemplate(templateName), WithNodeSelector(nodeName), WithNamespace(namespace))
+	if err != nil {
+		return "", fmt.Errorf("running node-collector job: %w", err)
+	}
+	err = New().Run(ctx, NewRunnableJob(jb.cluster.GetK8sClientSet(), job))
+	if err != nil {
+		return "", fmt.Errorf("running node-collector job: %w", err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("running node-collector job: %w", err)
+	}
+	defer func() {
+		background := metav1.DeletePropagationBackground
+		_ = jb.cluster.GetK8sClientSet().BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+			PropagationPolicy: &background,
+		})
+	}()
+
+	logsStream, err := jb.logsReader.GetLogsByJobAndContainerName(ctx, job, containerName)
+	if err != nil {
+		return "", fmt.Errorf("getting logs: %w", err)
+	}
+	defer func() {
+		_ = logsStream.Close()
+	}()
+	output, err := io.ReadAll(logsStream)
+	if err != nil {
+		return "", fmt.Errorf("reading logs: %w", err)
+	}
+	return string(output), nil
+}
+
+// Apply deploy k8s job by template to specific node and namespace
+func (jb *jobCollector) Apply(ctx context.Context, templateName string, nodeName string, namespace string) (*batchv1.Job, error) {
+	job, err := GetJob(WithTemplate(templateName), WithNodeSelector(nodeName), WithNamespace(namespace))
+	if err != nil {
+		return job, err
+	}
+	job, err = jb.cluster.GetK8sClientSet().BatchV1().Jobs(job.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return job, err
+	}
+	return job, nil
+}

--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -27,13 +27,14 @@ type Collector interface {
 type jobCollector struct {
 	cluster k8s.Cluster
 	// timeout duration for collection job to complete it task before is cancelled default 0
-	timeout      time.Duration
-	logsReader   LogsReader
-	labels       map[string]string
-	annotation   map[string]string
-	templateName string
-	namespace    string
-	name         string
+	timeout        time.Duration
+	logsReader     LogsReader
+	labels         map[string]string
+	annotation     map[string]string
+	templateName   string
+	namespace      string
+	name           string
+	serviceAccount string
 }
 
 type CollectorOption func(*jobCollector)
@@ -68,6 +69,12 @@ func WithName(name string) CollectorOption {
 	}
 }
 
+func WithServiceAccount(sa string) CollectorOption {
+	return func(jc *jobCollector) {
+		jc.serviceAccount = sa
+	}
+}
+
 func WithJobTemplateName(name string) CollectorOption {
 	return func(jc *jobCollector) {
 		jc.templateName = name
@@ -96,6 +103,7 @@ func (jb *jobCollector) ApplyAndCollect(ctx context.Context, nodeName string) (s
 		WithTemplate(jb.templateName),
 		WithNodeSelector(nodeName),
 		WithNamespace(TrivyNamespace),
+		WithJobServiceAccount(jb.serviceAccount),
 		WithJobName(fmt.Sprintf("%s-%s", jb.templateName, nodeName)))
 	if err != nil {
 		return "", fmt.Errorf("running node-collector job: %w", err)

--- a/pkg/jobs/loader.go
+++ b/pkg/jobs/loader.go
@@ -1,0 +1,56 @@
+package jobs
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const jobFSFolder = "template"
+
+var (
+	//go:embed template
+	jobFS embed.FS
+)
+
+var jobTemplateMap map[string]string
+
+// Load job templates
+func init() {
+	dir, _ := jobFS.ReadDir(jobFSFolder)
+	jobTemplateMap = make(map[string]string, 0)
+	for _, r := range dir {
+		if !strings.Contains(r.Name(), ".yaml") {
+			continue
+		}
+		file, err := jobFS.Open(fmt.Sprintf("%s/%s", jobFSFolder, r.Name()))
+		if err != nil {
+			panic(err)
+		}
+		templateContent, err := io.ReadAll(file)
+		if err != nil {
+			panic(err)
+		}
+		var fileTemp map[string]interface{}
+		err = yaml.Unmarshal(templateContent, &fileTemp)
+		if err != nil {
+			panic(err)
+		}
+		if specVal, ok := fileTemp["metadata"].(map[string]interface{}); ok {
+			if nameVal, ok := specVal["name"].(string); ok {
+				jobTemplateMap[nameVal] = string(templateContent)
+			}
+		}
+	}
+}
+
+// GetTemplate returns the spec content
+func getTemplate(name string) string {
+	if template, ok := jobTemplateMap[name]; ok { // use embedded spec
+		return template
+	}
+	return ""
+}

--- a/pkg/jobs/loader_test.go
+++ b/pkg/jobs/loader_test.go
@@ -1,0 +1,31 @@
+package jobs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadSpecs(t *testing.T) {
+	tests := []struct {
+		name         string
+		specName     string
+		wantSpecPath string
+	}{
+		{name: "node-collector template", specName: "node-collector", wantSpecPath: "./template/node-collector.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantSpecPath != "" {
+				wantSpecData, err := os.ReadFile(tt.wantSpecPath)
+				assert.NoError(t, err)
+				gotSpecData := getTemplate(tt.specName)
+				assert.Equal(t, gotSpecData, string(wantSpecData))
+			} else {
+				assert.Empty(t, getTemplate(tt.specName), tt.name)
+			}
+		})
+	}
+}

--- a/pkg/jobs/logs.go
+++ b/pkg/jobs/logs.go
@@ -1,0 +1,96 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var podControlledByJobNotFoundErr = errors.New("pod for job not found")
+
+type LogsReader interface {
+	GetLogsByJobAndContainerName(ctx context.Context, job *batchv1.Job, containerName string) (io.ReadCloser, error)
+	GetTerminatedContainersStatusesByJob(ctx context.Context, job *batchv1.Job) (map[string]*corev1.ContainerStateTerminated, error)
+}
+
+type logsReader struct {
+	clientset kubernetes.Interface
+}
+
+func NewLogsReader(clientset kubernetes.Interface) LogsReader {
+	return &logsReader{
+		clientset: clientset,
+	}
+}
+
+func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batchv1.Job, containerName string) (io.ReadCloser, error) {
+	pod, err := r.getPodByJob(ctx, job)
+	if err != nil {
+		return nil, fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, err)
+	}
+	if pod == nil {
+		return nil, fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, podControlledByJobNotFoundErr)
+	}
+
+	return r.clientset.CoreV1().Pods(pod.Namespace).
+		GetLogs(pod.Name, &corev1.PodLogOptions{
+			Follow:    true,
+			Container: containerName,
+		}).Stream(ctx)
+}
+
+func (r *logsReader) GetTerminatedContainersStatusesByJob(ctx context.Context, job *batchv1.Job) (map[string]*corev1.ContainerStateTerminated, error) {
+	pod, err := r.getPodByJob(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+	statuses := GetTerminatedContainersStatusesByPod(pod)
+	return statuses, nil
+}
+
+func (r *logsReader) getPodByJob(ctx context.Context, job *batchv1.Job) (*corev1.Pod, error) {
+	refreshedJob, err := r.clientset.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	selector := fmt.Sprintf("controller-uid=%s", refreshedJob.Spec.Selector.MatchLabels["controller-uid"])
+	podList, err := r.clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	if podList != nil && len(podList.Items) > 0 {
+		return &podList.Items[0], nil
+	}
+	return nil, nil
+}
+
+func GetTerminatedContainersStatusesByPod(pod *corev1.Pod) map[string]*corev1.ContainerStateTerminated {
+	states := make(map[string]*corev1.ContainerStateTerminated)
+	if pod == nil {
+		return states
+	}
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.State.Terminated == nil {
+			continue
+		}
+		states[status.Name] = status.State.Terminated
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Terminated == nil {
+			continue
+		}
+		states[status.Name] = status.State.Terminated
+	}
+	return states
+}
+
+func IsPodControlledByJobNotFound(err error) bool {
+	return errors.Is(err, podControlledByJobNotFoundErr)
+}

--- a/pkg/jobs/logs.go
+++ b/pkg/jobs/logs.go
@@ -14,6 +14,7 @@ import (
 
 var podControlledByJobNotFoundErr = errors.New("pod for job not found")
 
+// LogsReader responsible for collecting container status and logs
 type LogsReader interface {
 	GetLogsByJobAndContainerName(ctx context.Context, job *batchv1.Job, containerName string) (io.ReadCloser, error)
 	GetTerminatedContainersStatusesByJob(ctx context.Context, job *batchv1.Job) (map[string]*corev1.ContainerStateTerminated, error)
@@ -23,12 +24,14 @@ type logsReader struct {
 	clientset kubernetes.Interface
 }
 
+// NewLogsReader instansiate new log reader
 func NewLogsReader(clientset kubernetes.Interface) LogsReader {
 	return &logsReader{
 		clientset: clientset,
 	}
 }
 
+// GetLogsByJobAndContainerName collect logs from container and return it reader
 func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batchv1.Job, containerName string) (io.ReadCloser, error) {
 	pod, err := r.getPodByJob(ctx, job)
 	if err != nil {
@@ -45,6 +48,7 @@ func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batc
 		}).Stream(ctx)
 }
 
+// GetTerminatedContainersStatusesByJob collect information about contianer status by job
 func (r *logsReader) GetTerminatedContainersStatusesByJob(ctx context.Context, job *batchv1.Job) (map[string]*corev1.ContainerStateTerminated, error) {
 	pod, err := r.getPodByJob(ctx, job)
 	if err != nil {
@@ -71,6 +75,7 @@ func (r *logsReader) getPodByJob(ctx context.Context, job *batchv1.Job) (*corev1
 	return nil, nil
 }
 
+// GetTerminatedContainersStatusesByPod collect information about contianer status by pod
 func GetTerminatedContainersStatusesByPod(pod *corev1.Pod) map[string]*corev1.ContainerStateTerminated {
 	states := make(map[string]*corev1.ContainerStateTerminated)
 	if pod == nil {

--- a/pkg/jobs/runnable_job.go
+++ b/pkg/jobs/runnable_job.go
@@ -1,0 +1,133 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+)
+
+var defaultResyncDuration = 30 * time.Minute
+
+type runnableJob struct {
+	clientset  kubernetes.Interface
+	logsReader LogsReader
+	job        *batchv1.Job // job to be run
+}
+
+// NewRunnableJob constructs a new Runnable task defined as Kubernetes
+func NewRunnableJob(
+	clientset kubernetes.Interface,
+	job *batchv1.Job,
+) Runnable {
+	return &runnableJob{
+		clientset:  clientset,
+		logsReader: NewLogsReader(clientset),
+		job:        job,
+	}
+}
+
+// Run runs synchronously the task as Kubernetes job.
+// This method blocks and waits for the job completion or failure.
+func (r *runnableJob) Run(ctx context.Context) error {
+	var err error
+	r.job, err = r.clientset.BatchV1().Jobs(r.job.Namespace).Create(ctx, r.job, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		r.clientset,
+		defaultResyncDuration,
+		informers.WithNamespace(r.job.Namespace),
+	)
+	jobsInformer := informerFactory.Batch().V1().Jobs()
+	eventsInformer := informerFactory.Core().V1().Events()
+	complete := make(chan error)
+
+	_, err = jobsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, newObj interface{}) {
+			newJob, ok := newObj.(*batchv1.Job)
+			if !ok {
+				return
+			}
+			if r.job.UID != newJob.UID {
+				return
+			}
+			if len(newJob.Status.Conditions) == 0 {
+				return
+			}
+			switch condition := newJob.Status.Conditions[0]; condition.Type {
+			case batchv1.JobComplete:
+				klog.V(3).Infof("Stopping runnable job on task completion with status: %s", batchv1.JobComplete)
+				complete <- nil
+			case batchv1.JobFailed:
+				klog.V(3).Infof("Stopping runnable job on task failure with status: %s", batchv1.JobFailed)
+				complete <- fmt.Errorf("job failed: %s: %s", condition.Reason, condition.Message)
+			}
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = eventsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			event := obj.(*corev1.Event)
+			if event.InvolvedObject.UID != r.job.UID {
+				return
+			}
+
+			if event.Type == corev1.EventTypeNormal {
+				klog.V(3).Infof("Event: %s (%s)", event.Message, event.Reason)
+			}
+
+			if event.Type == corev1.EventTypeWarning {
+				complete <- fmt.Errorf("warning event received: %s (%s)", event.Message, event.Reason)
+				return
+			}
+		},
+	})
+	if err != nil {
+		return err
+	}
+	informerFactory.Start(wait.NeverStop)
+	informerFactory.WaitForCacheSync(wait.NeverStop)
+
+	err = <-complete
+
+	if err != nil {
+		r.logTerminatedContainersErrors(ctx)
+	}
+
+	return err
+}
+
+func (r *runnableJob) logTerminatedContainersErrors(ctx context.Context) {
+	statuses, err := r.logsReader.GetTerminatedContainersStatusesByJob(ctx, r.job)
+	if err != nil {
+		klog.Errorf("Error while getting terminated containers statuses for job %q", r.job.Namespace+"/"+r.job.Name)
+	}
+
+	for container, status := range statuses {
+		if status.ExitCode == 0 {
+			continue
+		}
+		klog.Errorf("Container %s terminated with %s: %s", container, status.Reason, status.Message)
+	}
+}
+
+func GetActiveDeadlineSeconds(d time.Duration) *int64 {
+	if d > 0 {
+		return pointer.Int64(int64(d.Seconds()))
+	}
+	return nil
+}

--- a/pkg/jobs/runnable_job.go
+++ b/pkg/jobs/runnable_job.go
@@ -50,7 +50,6 @@ func (r *runnableJob) Run(ctx context.Context) error {
 		informers.WithNamespace(r.job.Namespace),
 	)
 	jobsInformer := informerFactory.Batch().V1().Jobs()
-	eventsInformer := informerFactory.Core().V1().Events()
 	complete := make(chan error)
 
 	_, err = jobsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -78,7 +77,7 @@ func (r *runnableJob) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
+	eventsInformer := informerFactory.Core().V1().Events()
 	_, err = eventsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			event := obj.(*corev1.Event)

--- a/pkg/jobs/runner.go
+++ b/pkg/jobs/runner.go
@@ -78,7 +78,7 @@ func (r *runner) runAndWaitForever() error {
 }
 
 func (r *runner) runWithTimeout(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(context.Background(), r.timeoutDuration)
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), r.timeoutDuration)
 	defer cancel()
 	klog.V(3).Infof("Running task with timeout: %v", r.timeoutDuration)
 	select {
@@ -87,7 +87,7 @@ func (r *runner) runWithTimeout(ctx context.Context) error {
 		klog.V(3).Infof("Stopping runner on task completion with error: %v", err)
 		return err
 	// Signaled when we run out of time.
-	case <-ctx.Done():
+	case <-ctxWithTimeout.Done():
 		klog.V(3).Info("Stopping runner on timeout")
 		return ErrTimeout
 	}

--- a/pkg/jobs/runner.go
+++ b/pkg/jobs/runner.go
@@ -78,7 +78,7 @@ func (r *runner) runAndWaitForever() error {
 }
 
 func (r *runner) runWithTimeout(ctx context.Context) error {
-	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), r.timeoutDuration)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.timeoutDuration)
 	defer cancel()
 	klog.V(3).Infof("Running task with timeout: %v", r.timeoutDuration)
 	select {

--- a/pkg/jobs/runner.go
+++ b/pkg/jobs/runner.go
@@ -1,0 +1,94 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// ErrTimeout is returned when Runner's Run method fails due to a timeout event.
+var ErrTimeout = errors.New("runner received timeout")
+
+// Runnable is the interface that wraps the basic Run method.
+//
+// Run should be implemented by any task intended to be executed by the Runner.
+type Runnable interface {
+	Run(ctx context.Context) error
+}
+
+// The RunnableFunc type is an adapter to allow the use of ordinary functions as Runnable tasks.
+// If f is a function with the appropriate signature, RunnableFunc(f) is a Runnable that calls f.
+type RunnableFunc func(ctx context.Context) error
+
+// Run calls f()
+func (f RunnableFunc) Run(ctx context.Context) error {
+	return f(ctx)
+}
+
+// Runner is the interface that wraps the basic Run method.
+//
+// Run executes submitted Runnable tasks.
+type Runner interface {
+	Run(ctx context.Context, task Runnable) error
+}
+
+// New constructs a new ready-to-use Runner for running a Runnable task.
+func New() Runner {
+	return &runner{
+		complete:        make(chan error),
+		timeoutDuration: 0,
+	}
+}
+
+// NewWithTimeout constructs a new ready-to-use Runner with the specified timeout for running a Runnable task.
+func NewWithTimeout(d time.Duration) Runner {
+	return &runner{
+		complete:        make(chan error),
+		timeoutDuration: d,
+		timeout:         time.After(d),
+	}
+}
+
+type runner struct {
+	// complete channel reports that processing is done
+	complete chan error
+	// timeout duration
+	timeoutDuration time.Duration
+	// timeout channel reports that time has run out
+	timeout <-chan time.Time
+}
+
+// Run runs the specified task and monitors channel events.
+func (r *runner) Run(ctx context.Context, task Runnable) (err error) {
+	go func() {
+		r.complete <- task.Run(ctx)
+	}()
+
+	if r.timeoutDuration > 0 {
+		err = r.runWithTimeout()
+		return
+	} else {
+		err = r.runAndWaitForever()
+		return
+	}
+}
+
+func (r *runner) runAndWaitForever() error {
+	return <-r.complete
+}
+
+func (r *runner) runWithTimeout() (err error) {
+	klog.V(3).Infof("Running task with timeout: %v", r.timeoutDuration)
+	select {
+	// Signaled when processing is done.
+	case err := <-r.complete:
+		klog.V(3).Infof("Stopping runner on task completion with error: %v", err)
+		return err
+	// Signaled when we run out of time.
+	case <-r.timeout:
+		klog.V(3).Info("Stopping runner on timeout")
+		return ErrTimeout
+	}
+}

--- a/pkg/jobs/template/node-collector.yaml
+++ b/pkg/jobs/template/node-collector.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: node-collector
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-collector
+    spec:
+      hostPID: true
+      containers:
+        - name: node-collector
+          image: ghcr.io/aquasecurity/node-collector:0.0.3
+          command:
+            - node-collector
+          volumeMounts:
+            - name: var-lib-etcd
+              mountPath: /var/lib/etcd
+              readOnly: true
+            - name: var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
+              readOnly: true
+            - name: etc-systemd
+              mountPath: /etc/systemd
+              readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: srv-kubernetes
+              mountPath: /srv/kubernetes/
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: usr-bin
+              mountPath: /usr/local/mount-from-host/bin
+              readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: var-lib-etcd
+          hostPath:
+            path: /var/lib/etcd
+        - name: var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: /var/lib/kube-scheduler
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: /var/lib/kube-controller-manager
+        - name: etc-systemd
+          hostPath:
+            path: /etc/systemd
+        - name: lib-systemd
+          hostPath:
+            path: /lib/systemd
+        - name: srv-kubernetes
+          hostPath:
+            path: /srv/kubernetes
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+        - name: etc-cni-netd
+          hostPath:
+            path: /etc/cni/net.d/
+        - name: opt-cni-bin
+          hostPath:
+            path: /opt/cni/bin/

--- a/pkg/jobs/template/node-collector.yaml
+++ b/pkg/jobs/template/node-collector.yaml
@@ -12,7 +12,7 @@ spec:
       hostPID: true
       containers:
         - name: node-collector
-          image: ghcr.io/aquasecurity/node-collector:0.0.4
+          image: ghcr.io/aquasecurity/node-collector:0.0.5
           command:
             - node-collector
           volumeMounts:

--- a/pkg/jobs/template/node-collector.yaml
+++ b/pkg/jobs/template/node-collector.yaml
@@ -12,7 +12,7 @@ spec:
       hostPID: true
       containers:
         - name: node-collector
-          image: ghcr.io/aquasecurity/node-collector:0.0.3
+          image: ghcr.io/aquasecurity/node-collector:0.0.4
           command:
             - node-collector
           volumeMounts:

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -101,14 +101,11 @@ func GetCluster(opts ...ClusterOption) (Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	restConfig, err := cf.ToRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-	return getCluster(clientConfig, restMapper, restConfig)
+
+	return getCluster(clientConfig, restMapper)
 }
 
-func getCluster(clientConfig clientcmd.ClientConfig, restMapper meta.RESTMapper, restConfig *rest.Config) (*cluster, error) {
+func getCluster(clientConfig clientcmd.ClientConfig, restMapper meta.RESTMapper) (*cluster, error) {
 	kubeConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err
@@ -119,12 +116,12 @@ func getCluster(clientConfig clientcmd.ClientConfig, restMapper meta.RESTMapper,
 		return nil, err
 	}
 	var kubeClientset *kubernetes.Clientset
-	if restConfig != nil {
-		kubeClientset, err = kubernetes.NewForConfig(restConfig)
-		if err != nil {
-			return nil, err
-		}
+
+	kubeClientset, err = kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
 	}
+
 	rawCfg, err := clientConfig.RawConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -30,7 +30,7 @@ func TestGetCurrentNamespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			fakeConfig := createValidTestConfig(test.Namespace)
-			cluster, err := getCluster(fakeConfig, nil)
+			cluster, err := getCluster(fakeConfig, nil, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, test.ExpectedNamespace, cluster.GetCurrentNamespace())
 		})
@@ -62,7 +62,7 @@ func TestGetGVR(t *testing.T) {
 
 		fakeConfig := createValidTestConfig("")
 
-		cluster, err := getCluster(fakeConfig, mapper)
+		cluster, err := getCluster(fakeConfig, mapper, nil)
 		assert.NoError(t, err)
 
 		gvr, err := cluster.GetGVR(test.Resource)

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -30,7 +30,7 @@ func TestGetCurrentNamespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			fakeConfig := createValidTestConfig(test.Namespace)
-			cluster, err := getCluster(fakeConfig, nil, nil)
+			cluster, err := getCluster(fakeConfig, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, test.ExpectedNamespace, cluster.GetCurrentNamespace())
 		})
@@ -62,7 +62,7 @@ func TestGetGVR(t *testing.T) {
 
 		fakeConfig := createValidTestConfig("")
 
-		cluster, err := getCluster(fakeConfig, mapper, nil)
+		cluster, err := getCluster(fakeConfig, mapper)
 		assert.NoError(t, err)
 
 		gvr, err := cluster.GetGVR(test.Resource)

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/jobs"
@@ -121,7 +122,7 @@ func (c *client) ListArtifactAndNodeInfo(ctx context.Context) ([]*artifacts.Arti
 		if resource.Kind != "Node" {
 			continue
 		}
-		jc := jobs.NewCollector(c.cluster)
+		jc := jobs.NewCollector(c.cluster, jobs.WithTimetout(time.Minute*5))
 		output, err := jc.ApplyAndCollect(ctx, jobs.ContainerName, resource.Name)
 		if err != nil {
 			return nil, err

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -34,7 +34,7 @@ type ArtifactsK8S interface {
 	ListArtifacts(context.Context) ([]*artifacts.Artifact, error)
 	// GetArtifact return kubernete scanable artifact
 	GetArtifact(context.Context, string, string) (*artifacts.Artifact, error)
-	// ListArtifactAndNodeInfo return kubernete scanable artifact an node info
+	// ListArtifactAndNodeInfo return kubernete scanable artifact and node info
 	ListArtifactAndNodeInfo(context.Context) ([]*artifacts.Artifact, error)
 }
 
@@ -122,7 +122,7 @@ func (c *client) ListArtifactAndNodeInfo(ctx context.Context) ([]*artifacts.Arti
 			continue
 		}
 		jc := jobs.NewCollector(c.cluster)
-		output, err := jc.ApplyAndCollect(ctx, "node-collector", resource.Name, "default")
+		output, err := jc.ApplyAndCollect(ctx, jobs.ContainerName, resource.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -116,13 +116,15 @@ func (c *client) ListArtifactAndNodeInfo(ctx context.Context) ([]*artifacts.Arti
 	if err != nil {
 		return nil, err
 	}
+	jc := jobs.NewCollector(c.cluster, jobs.WithTimetout(time.Minute*5), jobs.WithJobTemplateName(jobs.NodeCollectorName))
+	// delete trivy namespace
+	defer jc.Cleanup(ctx)
 
 	// collect node info
 	for _, resource := range artifactList {
 		if resource.Kind != "Node" {
 			continue
 		}
-		jc := jobs.NewCollector(c.cluster, jobs.WithTimetout(time.Minute*5), jobs.WithJobTemplateName(jobs.NodeCollectorName))
 		output, err := jc.ApplyAndCollect(ctx, resource.Name)
 		if err != nil {
 			return nil, err

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -122,8 +122,8 @@ func (c *client) ListArtifactAndNodeInfo(ctx context.Context) ([]*artifacts.Arti
 		if resource.Kind != "Node" {
 			continue
 		}
-		jc := jobs.NewCollector(c.cluster, jobs.WithTimetout(time.Minute*5))
-		output, err := jc.ApplyAndCollect(ctx, jobs.ContainerName, resource.Name)
+		jc := jobs.NewCollector(c.cluster, jobs.WithTimetout(time.Minute*5), jobs.WithJobTemplateName(jobs.NodeCollectorName))
+		output, err := jc.ApplyAndCollect(ctx, resource.Name)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add support for triggering `node-collector` job in cluster.
the collector will collect info from node and output it.
require to support both for trivy and operator.
Related :

- [epic](https://github.com/aquasecurity/trivy/issues/2198)
-  [story](https://github.com/aquasecurity/trivy/issues/2201)