### PR TITLE
feat: refining resource exclusion logic based on built-in or custom ownership

### DIFF
--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -30,12 +30,19 @@ func main() {
 
 	fmt.Println("Current namespace:", cluster.GetCurrentNamespace())
 
-	trivyk8s := trivyk8s.New(cluster, logger.Sugar())
+	trivyk8s := trivyk8s.New(cluster, logger.Sugar(), trivyk8s.WithExcludeOwned(true))
+
+	fmt.Println("Scanning kind 'pods' with exclude-owned=true")
+	artifacts, err := trivyk8s.Resources("pod").AllNamespaces().ListArtifacts(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	printArtifacts(artifacts)
 
 	fmt.Println("Scanning cluster")
 
 	//trivy k8s #cluster
-	artifacts, err := trivyk8s.ListArtifacts(ctx)
+	artifacts, err = trivyk8s.ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

This pull request centers around an enhancement to the exclusion logic based on resource ownership. If the resource is owned by built-in workloads then the resource should be excluded.

This change ensures that resources owned by custom owners(Like CRDs) are not mistakenly excluded, while ensuring that resources owned by built-in workloads are excluded.

For example, consider the scenario where there are two pods: one named `my-pod`, which doesn't have any owners, and another named `pod-with-crd-owner`, which is created and managed by a custom owner(`acid.postgres.com/v1/postgresql`), and other regular pods owned by built-in workload kinds.

```
kubectl get pods -o custom-columns="NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].kind"
NAME                                  OWNER
my-pod                                <none>
aws-for-fluent-bit-m46xg              DaemonSet
coredns-655c69d4f4-fg82d              ReplicaSet
coredns-655c69d4f4-kmx6c              ReplicaSet
ebs-csi-controller-846b7ddddb-nj6ks   ReplicaSet
ebs-csi-controller-846b7ddddb-tbl88   ReplicaSet
pod-with-crd-owner                    acid.postgres.com/v1
```

## Before
Since we currently do not verify whether the owner of the resource is a built-in workload, pod with custom owner is not listed when calling ListArtifact function as per PR #214.
```
go run example/trivy.go
Name: my-pod, Kind: Pod, Namespace: default, Images: [nginx:latest]
```

## After
Once we start validating the resource's owner, the pod with custom owner becomes visible in the listing when calling ListArtifact function.

```
go run example/trivy.go
Name: my-pod, Kind: Pod, Namespace: default, Images: [nginx:latest]
Name: pod-with-crd-owner, Kind: Pod, Namespace: kube-system, Images: [nginx:latest]
```
