### PR TITLE
chore: fix issue caused by ownerIsBuiltIn being true by default

### DIFF
--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -30,19 +30,20 @@ func main() {
 
 	fmt.Println("Current namespace:", cluster.GetCurrentNamespace())
 
+	trivyk8sCopy := trivyk8s.New(cluster, logger.Sugar(), trivyk8s.WithExcludeOwned(true))
 	trivyk8s := trivyk8s.New(cluster, logger.Sugar(), trivyk8s.WithExcludeOwned(true))
 
-	fmt.Println("Scanning kind 'pods' with exclude-owned=true")
-	artifacts, err := trivyk8s.Resources("pod").AllNamespaces().ListArtifacts(ctx)
+	fmt.Println("Scanning cluster")
+
+	//trivy k8s #cluster
+	artifacts, err := trivyk8s.ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 	printArtifacts(artifacts)
 
-	fmt.Println("Scanning cluster")
-
-	//trivy k8s #cluster
-	artifacts, err = trivyk8s.ListArtifacts(ctx)
+	fmt.Println("Scanning kind 'pods' with exclude-owned=true")
+	artifacts, err = trivyk8s.Resources("pod").AllNamespaces().ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -50,13 +51,13 @@ func main() {
 
 	fmt.Println("Scanning namespace 'default'")
 	//trivy k8s --namespace default
-	artifacts, err = trivyk8s.Namespace("default").ListArtifacts(ctx)
+	artifacts, err = trivyk8sCopy.Namespace("default").ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 	printArtifacts(artifacts)
 	fmt.Println("Scanning all namespaces ")
-	artifacts, err = trivyk8s.AllNamespaces().ListArtifacts(ctx)
+	artifacts, err = trivyk8sCopy.AllNamespaces().ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -65,7 +66,7 @@ func main() {
 	fmt.Println("Scanning namespace 'default', resource 'deployment/orion'")
 
 	//trivy k8s --namespace default deployment/orion
-	artifact, err := trivyk8s.Namespace("default").GetArtifact(ctx, "deploy", "orion")
+	artifact, err := trivyk8sCopy.Namespace("default").GetArtifact(ctx, "deploy", "orion")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func main() {
 	fmt.Println("Scanning 'deployments'")
 
 	//trivy k8s deployment
-	artifacts, err = trivyk8s.Namespace("default").Resources("deployment").ListArtifacts(ctx)
+	artifacts, err = trivyk8sCopy.Namespace("default").Resources("deployment").ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -82,7 +83,7 @@ func main() {
 
 	fmt.Println("Scanning 'cm,pods'")
 	//trivy k8s clusterroles,pods
-	artifacts, err = trivyk8s.Namespace("default").Resources("cm,pods").ListArtifacts(ctx)
+	artifacts, err = trivyk8sCopy.Namespace("default").Resources("cm,pods").ListArtifacts(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -112,7 +113,7 @@ func main() {
 	}
 
 	// collect node info
-	ar, err := trivyk8s.ListArtifactAndNodeInfo(ctx, "trivy-temp", map[string]string{"chen": "test"}, tolerations...)
+	ar, err := trivyk8sCopy.ListArtifactAndNodeInfo(ctx, "trivy-temp", map[string]string{"chen": "test"}, tolerations...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -138,12 +138,9 @@ func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, erro
 			if c.ignoreResource(resource) {
 				continue
 			}
-			// assume that the owner doesn't exists by default
-			ownerExists := false
 			// assume that the owner is a built-in workload by default
 			ownerIsBuiltIn := true
 			if len(resource.GetOwnerReferences()) > 0 {
-				ownerExists = true
 				// if the resource has an owner, we check if it is a built-in workload
 				// this ensures that we don't skip resources that are owned by custom resources
 				for _, owner := range resource.GetOwnerReferences() {
@@ -155,7 +152,7 @@ func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, erro
 			}
 
 			// if excludeOwned is enabled and workload is a built-in workload and if ownerExists, we skip it
-			if c.excludeOwned && ownerIsBuiltIn && ownerExists {
+			if c.excludeOwned && ownerIsBuiltIn && len(resource.GetOwnerReferences()) > 0 {
 				continue
 			}
 

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -138,10 +138,12 @@ func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, erro
 			if c.ignoreResource(resource) {
 				continue
 			}
-
+			// assume that the owner doesn't exists by default
+			ownerExists := false
 			// assume that the owner is a built-in workload by default
 			ownerIsBuiltIn := true
 			if len(resource.GetOwnerReferences()) > 0 {
+				ownerExists = true
 				// if the resource has an owner, we check if it is a built-in workload
 				// this ensures that we don't skip resources that are owned by custom resources
 				for _, owner := range resource.GetOwnerReferences() {
@@ -152,8 +154,8 @@ func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, erro
 				}
 			}
 
-			// if excludeOwned is enabled and workload is a built-in workload, we skip it
-			if c.excludeOwned && ownerIsBuiltIn {
+			// if excludeOwned is enabled and workload is a built-in workload and if ownerExists, we skip it
+			if c.excludeOwned && ownerIsBuiltIn && ownerExists {
 				continue
 			}
 


### PR DESCRIPTION
# Description

Pods without owners are ignored because `ownerIsBuiltIn` is `true` by default. As a result the condition in if statement evaluates to true and the Pods without owners are ignored.

https://github.com/aquasecurity/trivy-kubernetes/blob/95e88d51f82b2e6951258fdb7ad2dacebbdcb803/pkg/trivyk8s/trivyk8s.go#L156

This PR adds `ownerExists` boolean variable to fix this issue.


# Before
```
go run examples/trivy.go
Current namespace: default
Scanning kind 'pods' with exclude-owned=true
Name: pod-with-crd-owner, Kind: Pod, Namespace: kube-system, Images: [nginx:latest]
```

# After

```
go run examples/trivy.go
Current namespace: default
Scanning kind 'pods' with exclude-owned=true
Name: my-pod, Kind: Pod, Namespace: default, Images: [nginx:latest]
Name: pod-with-crd-owner, Kind: Pod, Namespace: kube-system, Images: [nginx:latest]
```