### PR TITLE
fix: constant job pod creation

### DIFF
--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -130,8 +130,10 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 		job.Spec.Template.Spec.Containers[0].Image = b.imageRef
 	}
 
-	if len(b.nodeSelector) > 0 {
-		job.Spec.Template.Spec.NodeName = b.nodeSelector
+	if b.nodeSelector != "" {
+		job.Spec.Template.Spec.NodeSelector = map[string]string{
+			"kubernetes.io/hostname": b.nodeSelector,
+		}
 	}
 	// append lables
 	for key, val := range b.labels {

--- a/pkg/jobs/builder.go
+++ b/pkg/jobs/builder.go
@@ -132,7 +132,7 @@ func (b *JobBuilder) build() (*batchv1.Job, error) {
 
 	if b.nodeSelector != "" {
 		job.Spec.Template.Spec.NodeSelector = map[string]string{
-			"kubernetes.io/hostname": b.nodeSelector,
+			corev1.LabelHostname: b.nodeSelector,
 		}
 	}
 	// append lables


### PR DESCRIPTION
Because `JobBuilder` uses manual scheduling (setted `.spec.template.spec.nodeName` in `Job` spec) for "node" jobs (for example, `node-collector` jobs in aquasecurity/trivy-operator) , if node has taints with NoExecute effect and job doesn't have tolerations for them, `kube-controller-manager` would constantly create and delete job pods on node (manual scheduling for node -> create pod -> taint with `NoExecute` effect -> delete pod -> repeat).
Using [kubernetes.io/hostname](https://github.com/kubernetes/kubernetes/blob/61d87fdb2e6c656f3d7123570c78ada5dca59079/pkg/kubelet/kubelet_node_status.go#L217) label with `nodeSelector` would help to fix this issue.