### PR TITLE
refactor: introduce 'hasOwner' function to reduce cognitive load

### DIFF
--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -94,7 +94,7 @@ func (c *client) Resources(resources string) TrivyK8S {
 	return c
 }
 
-func isNamspaced(namespace string, allNamespace bool) bool {
+func isNamespaced(namespace string, allNamespace bool) bool {
 	if len(namespace) != 0 || (len(namespace) == 0 && allNamespace) {
 		return true
 	}
@@ -105,7 +105,7 @@ func isNamspaced(namespace string, allNamespace bool) bool {
 func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, error) {
 	artifactList := make([]*artifacts.Artifact, 0)
 
-	namespaced := isNamspaced(c.namespace, c.allNamespaces)
+	namespaced := isNamespaced(c.namespace, c.allNamespaces)
 	grvs, err := c.cluster.GetGVRs(namespaced, c.resources)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this change, I introduced a new function named 'hasOwner' to enhance the code.

This function streamlines the logic for determining whether a resource is owned by a built-in workload in Kubernetes.

It introduces no change in the overall behavior of the code.

cc @chen-keinan 