### PR TITLE
feat: allow adjustment of  QPS/Burst values

### DIFF
--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -9,8 +9,6 @@ import (
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	tk "github.com/aquasecurity/trivy-kubernetes/pkg/trivyk8s"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/rest"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -19,37 +17,6 @@ import (
 	"context"
 )
 
-func WithQPS(qps float32) k8s.ClusterOption {
-	return func(o *genericclioptions.ConfigFlags) {
-		o.WrapConfigFn = combineConfigFns(o.WrapConfigFn, func(c *rest.Config) *rest.Config {
-			c.QPS = qps
-			return c
-		})
-	}
-}
-
-func WithBurst(burst int) k8s.ClusterOption {
-	return func(o *genericclioptions.ConfigFlags) {
-		o.WrapConfigFn = combineConfigFns(o.WrapConfigFn, func(c *rest.Config) *rest.Config {
-			c.Burst = burst
-			return c
-		})
-	}
-}
-
-// Helper function to combine multiple config functions
-func combineConfigFns(existing, newFn func(*rest.Config) *rest.Config) func(*rest.Config) *rest.Config {
-	if existing == nil {
-		return newFn
-	}
-	return func(c *rest.Config) *rest.Config {
-		if modified := existing(c); modified != nil {
-			return newFn(modified)
-		}
-		return newFn(c)
-	}
-}
-
 func main() {
 
 	logger, _ := zap.NewProduction()
@@ -57,7 +24,7 @@ func main() {
 
 	ctx := context.Background()
 
-	cluster, err := k8s.GetCluster(WithBurst(100), WithQPS(100))
+	cluster, err := k8s.GetCluster(k8s.WithBurst(1), k8s.WithQPS(1))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/trivy.go
+++ b/examples/trivy.go
@@ -24,7 +24,7 @@ func main() {
 
 	ctx := context.Background()
 
-	cluster, err := k8s.GetCluster(k8s.WithBurst(1), k8s.WithQPS(1))
+	cluster, err := k8s.GetCluster(k8s.WithBurst(100), k8s.WithQPS(100))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -151,12 +151,12 @@ func GetCluster(opts ...ClusterOption) (Cluster, error) {
 
 	clientConfig := cf.ToRawKubeConfigLoader()
 
-	kubeConfig, err := cf.ToRESTConfig()
+	restMapper, err := cf.ToRESTMapper()
 	if err != nil {
 		return nil, err
 	}
 
-	restMapper, err := cf.ToRESTMapper()
+	kubeConfig, err := cf.ToRESTConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -138,6 +138,36 @@ func WithKubeConfig(kubeConfig string) ClusterOption {
 		c.KubeConfig = &kubeConfig
 	}
 }
+func WithQPS(qps float32) ClusterOption {
+	return func(o *genericclioptions.ConfigFlags) {
+		o.WrapConfigFn = combineConfigFns(o.WrapConfigFn, func(c *rest.Config) *rest.Config {
+			c.QPS = qps
+			return c
+		})
+	}
+}
+
+func WithBurst(burst int) ClusterOption {
+	return func(o *genericclioptions.ConfigFlags) {
+		o.WrapConfigFn = combineConfigFns(o.WrapConfigFn, func(c *rest.Config) *rest.Config {
+			c.Burst = burst
+			return c
+		})
+	}
+}
+
+// Helper function to combine multiple config functions
+func combineConfigFns(existing, newFn func(*rest.Config) *rest.Config) func(*rest.Config) *rest.Config {
+	if existing == nil {
+		return newFn
+	}
+	return func(c *rest.Config) *rest.Config {
+		if modified := existing(c); modified != nil {
+			return newFn(modified)
+		}
+		return newFn(c)
+	}
+}
 
 // GetCluster returns a current configured cluster,
 func GetCluster(opts ...ClusterOption) (Cluster, error) {

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -151,19 +151,20 @@ func GetCluster(opts ...ClusterOption) (Cluster, error) {
 
 	clientConfig := cf.ToRawKubeConfigLoader()
 
+	kubeConfig, err := cf.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	restMapper, err := cf.ToRESTMapper()
 	if err != nil {
 		return nil, err
 	}
 
-	return getCluster(clientConfig, restMapper, *cf.Context, false)
+	return getCluster(clientConfig, kubeConfig, restMapper, *cf.Context, false)
 }
 
-func getCluster(clientConfig clientcmd.ClientConfig, restMapper meta.RESTMapper, currentContext string, fakeConfig bool) (*cluster, error) {
-	kubeConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
+func getCluster(clientConfig clientcmd.ClientConfig, kubeConfig *rest.Config, restMapper meta.RESTMapper, currentContext string, fakeConfig bool) (*cluster, error) {
 
 	k8sDynamicClient, err := dynamic.NewForConfig(kubeConfig)
 	if err != nil {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -34,7 +34,9 @@ func TestGetCurrentNamespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			fakeConfig := createValidTestConfig(test.Namespace)
-			cluster, err := getCluster(fakeConfig, nil, "", true)
+			fakeKubeconfig, err := fakeConfig.ClientConfig()
+			assert.NoError(t, err)
+			cluster, err := getCluster(fakeConfig, fakeKubeconfig, nil, "", true)
 			assert.NoError(t, err)
 			assert.Equal(t, test.ExpectedNamespace, cluster.GetCurrentNamespace())
 		})
@@ -66,7 +68,10 @@ func TestGetGVR(t *testing.T) {
 
 		fakeConfig := createValidTestConfig("")
 
-		cluster, err := getCluster(fakeConfig, mapper, "", true)
+		fakeKubeconfig, err := fakeConfig.ClientConfig()
+		assert.NoError(t, err)
+
+		cluster, err := getCluster(fakeConfig, fakeKubeconfig, mapper, "", true)
 		assert.NoError(t, err)
 
 		gvr, err := cluster.GetGVR(test.Resource)


### PR DESCRIPTION
This PR intents to allow end users to use custom QPS/Burst value with `trivy-kubernetes` library with wrapper functions

Output after QPS/Burst value set to 100/100 (after this PR)
```
Current namespace: default
Scanning cluster
Scan took 79.106125ms
```

Output with no overrides(before this PR)
```
Current namespace: default
Scanning cluster
Scan took 2.043902375s
```

@chen-keinan This PR fixes the issues we discussed in #262 