### PR TITLE
fix: handle non parsable images name

### DIFF
--- a/pkg/artifacts/artifacts.go
+++ b/pkg/artifacts/artifacts.go
@@ -33,7 +33,7 @@ func FromResource(resource unstructured.Unstructured, serverAuths map[string]doc
 		for _, im := range cTypeImages {
 			as, err := k8s.MapContainerNamesToDockerAuths(im, serverAuths)
 			if err != nil {
-				return nil, err
+				continue
 			}
 			if as != nil {
 				credentials = append(credentials, *as)

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -473,7 +473,7 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 	for _, s := range pod.Status.ContainerStatuses {
 		imageName, err := utils.ParseReference(s.Image)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		imageID := getImageID(s.ImageID, s.Image)
 		if len(imageID) == 0 {
@@ -481,7 +481,7 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 		}
 		imageRef, err := utils.ParseReference(imageID)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		co, err := GetContainer(imageRef, imageName)
 		if err != nil {

--- a/utils/referance_test.go
+++ b/utils/referance_test.go
@@ -16,4 +16,9 @@ func TestParseRef(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "k8s.gcr.io/etcd:3.4.13-0", imageRef.String())
 	})
+	t.Run("parses imgae ref without arn", func(t *testing.T) {
+		imageRef, err := ParseReference("ToBeReplaced:0.0.1")
+		assert.NoError(t, err)
+		assert.Equal(t, "k8s.gcr.io/etcd:3.4.13-0", imageRef.String())
+	})
 }

--- a/utils/referance_test.go
+++ b/utils/referance_test.go
@@ -16,9 +16,4 @@ func TestParseRef(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "k8s.gcr.io/etcd:3.4.13-0", imageRef.String())
 	})
-	t.Run("parses imgae ref without arn", func(t *testing.T) {
-		imageRef, err := ParseReference("ToBeReplaced:0.0.1")
-		assert.NoError(t, err)
-		assert.Equal(t, "k8s.gcr.io/etcd:3.4.13-0", imageRef.String())
-	})
 }


### PR DESCRIPTION
## Description
handle non parsable images name

- Related https://github.com/aquasecurity/trivy/issues/5943