### PR TITLE
fix: use of specified context to obtain cluster name

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -579,7 +579,12 @@ func (c *cluster) ClusterNameVersion() (string, string, error) {
 	}
 	clusterName := "k8s.io/kubernetes"
 	if len(rawCfg.Contexts) > 0 {
-		clusterName = rawCfg.Contexts[rawCfg.CurrentContext].Cluster
+		if c.currentContext != "" {
+			rawCfg.CurrentContext = c.currentContext
+		}
+		if clusterContext, ok := rawCfg.Contexts[rawCfg.CurrentContext]; ok {
+			clusterName = clusterContext.Cluster
+		}
 	}
 	version, err := c.clientset.ServerVersion()
 	if err != nil {


### PR DESCRIPTION
## Description
Use of specified context to obtain cluster name

- Related https://github.com/aquasecurity/trivy/issues/6643