### PR TITLE
fix: handle resource has no permission error

### DIFF
--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -173,7 +173,7 @@ func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, erro
 		if err != nil {
 			lerr := fmt.Errorf("failed listing resources for gvr: %v - %w", gvr, err)
 
-			if errors.IsNotFound(err) {
+			if errors.IsNotFound(err) || errors.IsForbidden(err) {
 				slog.Error("Unable to list resources", "error", lerr)
 				// if a resource is not found, we log and continue
 				continue

--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -175,7 +175,6 @@ func (c *client) ListArtifacts(ctx context.Context) ([]*artifacts.Artifact, erro
 
 			if errors.IsNotFound(err) || errors.IsForbidden(err) {
 				slog.Error("Unable to list resources", "error", lerr)
-				// if a resource is not found, we log and continue
 				continue
 			}
 


### PR DESCRIPTION
## Description
Handle resource has no permission error

- Related https://github.com/aquasecurity/trivy/issues/6692