### PR TITLE
fix: add new status conditions for k8s v1.31

### DIFF
--- a/pkg/jobs/runnable_job.go
+++ b/pkg/jobs/runnable_job.go
@@ -65,9 +65,9 @@ func (r *runnableJob) Run(ctx context.Context) error {
 				return
 			}
 			switch condition := newJob.Status.Conditions[0]; condition.Type {
-			case batchv1.JobComplete:
+			case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet:
 				complete <- nil
-			case batchv1.JobFailed:
+			case batchv1.JobFailed, batchv1.JobFailureTarget:
 				complete <- fmt.Errorf("job failed: %s: %s", condition.Reason, condition.Message)
 			}
 		},

--- a/pkg/jobs/runnable_job.go
+++ b/pkg/jobs/runnable_job.go
@@ -64,10 +64,10 @@ func (r *runnableJob) Run(ctx context.Context) error {
 			if len(newJob.Status.Conditions) == 0 {
 				return
 			}
-			switch condition := newJob.Status.Conditions[0]; condition.Type {
-			case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet:
+
+			if newJob.Status.Conditions[0].Type == batchv1.JobComplete || newJob.Status.Conditions[0].Type == batchv1.JobSuccessCriteriaMet {
 				complete <- nil
-			case batchv1.JobFailed, batchv1.JobFailureTarget:
+			} else if condition := newJob.Status.Conditions[len(newJob.Status.Conditions)-1]; condition.Type == batchv1.JobFailed {
 				complete <- fmt.Errorf("job failed: %s: %s", condition.Reason, condition.Message)
 			}
 		},

--- a/pkg/jobs/runnable_job.go
+++ b/pkg/jobs/runnable_job.go
@@ -61,9 +61,6 @@ func (r *runnableJob) Run(ctx context.Context) error {
 			if r.job.UID != newJob.UID {
 				return
 			}
-			if len(newJob.Status.Conditions) == 0 {
-				return
-			}
 			for _, condition := range newJob.Status.Conditions {
 				switch condition.Type {
 				case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet:


### PR DESCRIPTION
In Kubernetes v1.31.* the diagram of transitions looks like below. 
so we can complete the job after the first success, but we should wait for all pods are terminated.
<img width="1073" src="https://github.com/user-attachments/assets/372529fc-1dcd-4088-9c58-4e16990d9b2c">
the docs: [Transition of "status.conditions"](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3998-job-success-completion-policy#transition-of-statusconditions)