### PR TITLE
feat: add default commands for unknown platform

### DIFF
--- a/pkg/jobs/collector.go
+++ b/pkg/jobs/collector.go
@@ -487,6 +487,8 @@ func filterCommandByPlatform(commands map[string][]any, platform string) NodeCom
 	filteredCommands := make([]any, 0)
 	if command, ok := commands[platform]; ok {
 		filteredCommands = append(filteredCommands, command...)
+	} else {
+		filteredCommands = append(filteredCommands, commands["k8s"]...)
 	}
 	return NodeCommands{Commands: filteredCommands}
 }

--- a/pkg/jobs/collector_test.go
+++ b/pkg/jobs/collector_test.go
@@ -250,8 +250,8 @@ func TestFilterCommandsByPlatform(t *testing.T) {
 			},
 		},
 		{
-			name:        "select AKS commands",
-			platform:    "aks",
+			name:        "select commands for unknown platform (by default, using `k8s`)",
+			platform:    "unknown-ks",
 			commandsMap: commandsMap,
 			want: &NodeCommands{
 				Commands: commandsK8s,

--- a/pkg/jobs/collector_test.go
+++ b/pkg/jobs/collector_test.go
@@ -178,71 +178,82 @@ func TestFilterCommands(t *testing.T) {
 }
 
 func TestFilterCommandsByPlatform(t *testing.T) {
+	commandsK8s := []any{
+		map[string]interface{}{
+			"id":        "CMD-0001",
+			"title":     "kubelet.conf file permissions",
+			"key":       "kubeletConfFilePermissions",
+			"nodeType":  "worker",
+			"audit":     "stat -c %a $kubelet.kubeconfig",
+			"platforms": []interface{}{"k8s", "rke2"},
+		},
+		map[string]interface{}{
+			"id":        "CMD-0002",
+			"title":     "kubelet.conf file permissions",
+			"key":       "kubeletConfFilePermissions",
+			"nodeType":  "worker",
+			"audit":     "stat -c %a $kubelet.kubeconfig",
+			"platforms": []interface{}{"k8s", "rke2"},
+		},
+	}
+	commandsRKE2 := []any{
+		map[string]interface{}{
+			"id":        "CMD-0001",
+			"title":     "kubelet.conf file permissions",
+			"key":       "kubeletConfFilePermissions",
+			"nodeType":  "worker",
+			"audit":     "stat -c %a $kubelet.kubeconfig",
+			"platforms": []interface{}{"k8s", "rke2"},
+		},
+		map[string]interface{}{
+			"id":        "CMD-0002",
+			"title":     "kubelet.conf file permissions",
+			"key":       "kubeletConfFilePermissions",
+			"nodeType":  "worker",
+			"audit":     "stat -c %a $kubelet.kubeconfig",
+			"platforms": []interface{}{"k8s", "rke2"},
+		},
+	}
+	commandsMap := map[string][]any{
+		"k8s":  commandsK8s,
+		"rke2": commandsRKE2,
+	}
+
 	tests := []struct {
 		name        string
 		platform    string
 		commandsMap map[string][]any
 		want        *NodeCommands
 	}{
-		{name: "node-collector template",
-			platform: "k8s",
-			commandsMap: map[string][]any{
-				"k8s": {
-					map[string]interface{}{
-						"id":        "CMD-0001",
-						"title":     "kubelet.conf file permissions",
-						"key":       "kubeletConfFilePermissions",
-						"nodeType":  "worker",
-						"audit":     "stat -c %a $kubelet.kubeconfig",
-						"platforms": []interface{}{"k8s", "aks"},
-					},
-					map[string]interface{}{
-						"id":        "CMD-0002",
-						"title":     "kubelet.conf file permissions",
-						"key":       "kubeletConfFilePermissions",
-						"nodeType":  "worker",
-						"audit":     "stat -c %a $kubelet.kubeconfig",
-						"platforms": []interface{}{"k8s", "aks"},
-					},
-				},
-				"aks": {
-					map[string]interface{}{
-						"id":        "CMD-0001",
-						"title":     "kubelet.conf file permissions",
-						"key":       "kubeletConfFilePermissions",
-						"nodeType":  "worker",
-						"audit":     "stat -c %a $kubelet.kubeconfig",
-						"platforms": []interface{}{"k8s", "aks"},
-					},
-					map[string]interface{}{
-						"id":        "CMD-0002",
-						"title":     "kubelet.conf file permissions",
-						"key":       "kubeletConfFilePermissions",
-						"nodeType":  "worker",
-						"audit":     "stat -c %a $kubelet.kubeconfig",
-						"platforms": []interface{}{"k8s", "aks"},
-					},
-				},
-			},
+		{
+			name:        "select k8s commands",
+			platform:    "k8s",
+			commandsMap: commandsMap,
 			want: &NodeCommands{
-				Commands: []any{
-					map[string]interface{}{
-						"id":        "CMD-0001",
-						"title":     "kubelet.conf file permissions",
-						"key":       "kubeletConfFilePermissions",
-						"nodeType":  "worker",
-						"audit":     "stat -c %a $kubelet.kubeconfig",
-						"platforms": []interface{}{"k8s", "aks"},
-					},
-					map[string]interface{}{
-						"id":        "CMD-0002",
-						"title":     "kubelet.conf file permissions",
-						"key":       "kubeletConfFilePermissions",
-						"nodeType":  "worker",
-						"audit":     "stat -c %a $kubelet.kubeconfig",
-						"platforms": []interface{}{"k8s", "aks"},
-					},
-				},
+				Commands: commandsK8s,
+			},
+		},
+		{
+			name:        "select RKE2 commands",
+			platform:    "rke2",
+			commandsMap: commandsMap,
+			want: &NodeCommands{
+				Commands: commandsRKE2,
+			},
+		},
+		{
+			name:        "select AKS commands",
+			platform:    "aks",
+			commandsMap: commandsMap,
+			want: &NodeCommands{
+				Commands: commandsK8s,
+			},
+		},
+		{
+			name:     "without command maps",
+			platform: "aks",
+			want: &NodeCommands{
+				Commands: make([]any, 0),
 			},
 		},
 	}

--- a/pkg/jobs/collector_test.go
+++ b/pkg/jobs/collector_test.go
@@ -195,6 +195,14 @@ func TestFilterCommandsByPlatform(t *testing.T) {
 			"audit":     "stat -c %a $kubelet.kubeconfig",
 			"platforms": []interface{}{"k8s", "rke2"},
 		},
+		map[string]interface{}{
+			"id":        "CMD-0001",
+			"title":     "kubelet.conf file permissions",
+			"key":       "kubeletConfFilePermissions",
+			"nodeType":  "worker",
+			"audit":     "stat -c %a $kubelet.kubeconfig",
+			"platforms": []interface{}{"k8s"},
+		},
 	}
 	commandsRKE2 := []any{
 		map[string]interface{}{


### PR DESCRIPTION
This PR adds default command for unknown platforms.

the test cases was updated. I couldn't find `aks` platfrom in Trivy-check kubernetes commands: https://github.com/aquasecurity/trivy-checks/blob/main/commands/kubernetes/.
so I've changed `aks` to `rke2`, and using `aks` as unknown platform.

## Related issues
- https://github.com/aquasecurity/trivy/issues/7786