### PR TITLE
fix: get correct image digest from control-plane pods

### DIFF
--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -156,7 +156,43 @@ func TestPodInfo(t *testing.T) {
 						Version:    "v1.21.1",
 						Repository: "kube-apiserver",
 						Registry:   "k8s.gcr.io",
-						Digest:     "18e61c783b41758dd391ab901366ec3546b26fae00eef7e223d1f94da808e02f",
+						Digest:     "sha256:18e61c783b41758dd391ab901366ec3546b26fae00eef7e223d1f94da808e02f",
+					},
+				},
+			},
+		},
+		{
+			Name:          "etcd on docker",
+			labelSelector: "component",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd-minikube",
+					Namespace: "kube-system",
+					Labels:    map[string]string{"component": "etcd"},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Image:   "registry.k8s.io/etcd:3.5.15-0",
+						ImageID: "docker-pullable://registry.k8s.io/etcd@sha256:a6dc63e6e8cfa0307d7851762fa6b629afb18f28d8aa3fab5a6e91b4af60026a",
+					},
+					},
+				},
+			},
+			want: &bom.Component{
+				Namespace: "kube-system",
+				Name:      "go.etcd.io/etcd/v3",
+				Version:   "3.5.15-0",
+				Properties: map[string]string{
+					"Name": "etcd-minikube",
+					"Type": "controlPlane",
+				},
+				Containers: []bom.Container{
+					{
+						ID:         "etcd:3.5.15-0",
+						Version:    "3.5.15-0",
+						Repository: "etcd",
+						Registry:   "registry.k8s.io",
+						Digest:     "sha256:a6dc63e6e8cfa0307d7851762fa6b629afb18f28d8aa3fab5a6e91b4af60026a",
 					},
 				},
 			},


### PR DESCRIPTION
Actually, based on [OCI Image spec](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests), `digest` should be `algorithm ":" encoded`, instead of a hash code.