### PR TITLE
feat: add ingress-nginx controller components

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	UpstreamOrgName = map[string]string{
-		"k8s.io":      "controller-manager,kubelet,apiserver,kubectl,kubernetes,kube-scheduler,kube-proxy,cloud-provider",
+		"k8s.io":      "controller-manager,kubelet,apiserver,kubectl,kubernetes,kube-scheduler,kube-proxy,cloud-provider,ingress-nginx",
 		"sigs.k8s.io": "secrets-store-csi-driver",
 		"go.etcd.io":  "etcd/v3",
 	}
@@ -456,6 +456,7 @@ func (c *cluster) CreateClusterBom(ctx context.Context) (*bom.Result, error) {
 		return nil, err
 	}
 	addonLabels := map[string]string{
+		"":                    "app.kubernetes.io/component=controller",
 		k8sComponentNamespace: "k8s-app",
 	}
 	addons, err := c.collectComponents(ctx, addonLabels)
@@ -473,7 +474,6 @@ func (c *cluster) CreateClusterBom(ctx context.Context) (*bom.Result, error) {
 func GetContainer(hex string, imageName containerimage.Reference) (bom.Container, error) {
 	repoName := imageName.Context().RepositoryStr()
 	registryName := imageName.Context().RegistryStr()
-
 	return bom.Container{
 		Repository: repoName,
 		Registry:   registryName,
@@ -564,6 +564,7 @@ func (c *cluster) collectComponents(ctx context.Context, labels map[string]strin
 func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 	containers := make([]bom.Container, 0)
 	for _, s := range pod.Status.ContainerStatuses {
+
 		imageName, err := utils.ParseReference(s.Image)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("unable to parse image reference, skipping: %s", s.Image))
@@ -590,24 +591,35 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 		containers = append(containers, co)
 	}
 	props := make(map[string]string)
-	componentValue, ok := pod.GetLabels()[labelSelector]
-	if ok {
-		props["Name"] = pod.Name
+
+	labels := pod.GetLabels()
+
+	name, version := labels["app.kubernetes.io/name"], labels["app.kubernetes.io/version"]
+	props["Name"] = pod.Name
+
+	if name == "" {
+		componentValue := pod.GetLabels()[labelSelector]
+		name = upstreamRepoByName(componentValue)
+		if val, ok := CoreComponentPropertyType[name]; ok {
+			props["Type"] = val
+		}
+	}
+	orgName := upstreamOrgByName(name)
+	if len(orgName) > 0 {
+		name = fmt.Sprintf("%s/%s", orgName, name)
 	}
 
-	repoName := upstreamRepoByName(componentValue)
-	if val, ok := CoreComponentPropertyType[repoName]; ok {
-		props["Type"] = val
+	if props["Type"] == "" {
+		props["Type"] = "controlPlane"
 	}
-	orgName := upstreamOrgByName(repoName)
-	upstreamComponentName := repoName
-	if len(orgName) > 0 {
-		upstreamComponentName = fmt.Sprintf("%s/%s", orgName, repoName)
+
+	if version == "" {
+		version = trimString(findComponentVersion(containers, pod.GetLabels()[labelSelector]), []string{"v", "V"})
 	}
-	version := trimString(findComponentVersion(containers, componentValue), []string{"v", "V"})
+
 	return &bom.Component{
 		Namespace:  pod.Namespace,
-		Name:       upstreamComponentName,
+		Name:       name,
 		Version:    version,
 		Properties: props,
 		Containers: containers,
@@ -895,6 +907,7 @@ func upstreamRepoByName(component string) string {
 	if val, ok := UpstreamRepoName[component]; ok {
 		return val
 	}
+
 	return component
 }
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -597,7 +597,7 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 	props["Name"] = pod.Name
 
 	if name == "" {
-		componentValue := pod.GetLabels()[labelSelector]
+		componentValue := labels[labelSelector]
 		name = upstreamRepoByName(componentValue)
 		if val, ok := CoreComponentPropertyType[name]; ok {
 			props["Type"] = val
@@ -613,7 +613,7 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 	}
 
 	if version == "" {
-		version = trimString(findComponentVersion(containers, pod.GetLabels()[labelSelector]), []string{"v", "V"})
+		version = trimString(findComponentVersion(containers, labels[labelSelector]), []string{"v", "V"})
 	}
 
 	return &bom.Component{

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -564,7 +564,6 @@ func (c *cluster) collectComponents(ctx context.Context, labels map[string]strin
 func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 	containers := make([]bom.Container, 0)
 	for _, s := range pod.Status.ContainerStatuses {
-
 		imageName, err := utils.ParseReference(s.Image)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("unable to parse image reference, skipping: %s", s.Image))

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -595,6 +595,7 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 
 	name, version := labels["app.kubernetes.io/name"], labels["app.kubernetes.io/version"]
 	props["Name"] = pod.Name
+	props["Type"] = labels["app.kubernetes.io/component"]
 
 	if name == "" {
 		componentValue := labels[labelSelector]
@@ -606,10 +607,6 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 	orgName := upstreamOrgByName(name)
 	if len(orgName) > 0 {
 		name = fmt.Sprintf("%s/%s", orgName, name)
-	}
-
-	if props["Type"] == "" {
-		props["Type"] = "controlPlane"
 	}
 
 	if version == "" {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -161,6 +161,40 @@ func TestPodInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:          "ingress-nginx controller",
+			labelSelector: "app.kubernetes.io/component=controller",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-nginx-controller-8547bfc86c-dr7lq",
+					Namespace: "ingress-nginx",
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "controller",
+						"app.kubernetes.io/instance":  "ingress-nginx",
+						"app.kubernetes.io/name":      "ingress-nginx",
+						"app.kubernetes.io/part-of":   "ingress-nginx",
+						"app.kubernetes.io/version":   "1.11.0",
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Image:   "sha256:560a9fa980f663e5b71a6ca2df40f504fa577d0e38f9d0aed06c2a8eff53cb50",
+						ImageID: "registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+					},
+					},
+				},
+			},
+			want: &bom.Component{
+				Namespace: "ingress-nginx",
+				Name:      "k8s.io/ingress-nginx",
+				Version:   "1.11.0",
+				Properties: map[string]string{
+					"Name": "ingress-nginx-controller-8547bfc86c-dr7lq",
+					"Type": "controller",
+				},
+				Containers: []bom.Container{},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
This PR introduces the ability to retrieve pods from k8s that are marked as controller components (based on the label "app.kubernetes.io/component=controller").

The resource name and version are determined based on available labels, if present.

Prepare:
```sh
$ kind delete cluster && kind create cluster && kubectl wait --for=condition=Ready --all nodes
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.0/deploy/static/provider/cloud/deploy.yaml
$ trivy k8s --format cyclonedx -o kbom.cdx --report all
```
Before:
```sh
$ trivy sbom kbom.cdx
...
Report Summary

┌──────────────────────┬────────────┬─────────────────┐
│        Target        │    Type    │ Vulnerabilities │
├──────────────────────┼────────────┼─────────────────┤
│ kbom.cdx (debian 12) │   debian   │        0        │
├──────────────────────┼────────────┼─────────────────┤
│                      │  gobinary  │        0        │
├──────────────────────┼────────────┼─────────────────┤
│ Kubernetes           │ kubernetes │        0        │
└──────────────────────┴────────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```
After:
```sh
$ trivy sbom kbom.cdx
...
Report Summary

┌──────────────────────┬────────────┬─────────────────┐
│        Target        │    Type    │ Vulnerabilities │
├──────────────────────┼────────────┼─────────────────┤
│ kbom.cdx (debian 12) │   debian   │        0        │
├──────────────────────┼────────────┼─────────────────┤
│                      │  gobinary  │        0        │
├──────────────────────┼────────────┼─────────────────┤
│ Kubernetes           │ kubernetes │        1        │
└──────────────────────┴────────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


Kubernetes (kubernetes)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌──────────────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────┐
│       Library        │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                   Title                    │
├──────────────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────┤
│ k8s.io/ingress-nginx │ CVE-2024-7646 │ HIGH     │ fixed  │ v1.11.0           │ 1.11.2        │ Ingress-nginx Annotation Validation Bypass │
│                      │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-7646  │
└──────────────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────┘
``