### PR TITLE
fix: correct compare docker version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   verify-code:
     name: Verify code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -69,7 +69,7 @@ jobs:
         run: go mod vendor
   unit-tests:
     name: Run unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   unit-tests:
     name: Run unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -37,7 +37,7 @@ jobs:
     name: Release
     needs:
       - unit-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -502,7 +502,7 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 	hex := extractDigest(imageId)
 	// skip non sha256 digests
 	if len(hex) != digest.Canonical.Size()*2 {
-		return bom.Container{}, fmt.Errorf("unable to parse digest %q for %q: %v", imageName, imageName, err)
+		return bom.Container{}, fmt.Errorf("unable to parse digest %q for %q", imageName, imageName)
 	}
 
 	repoName := imageRef.Context().RepositoryStr()

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -472,14 +472,6 @@ func (c *cluster) CreateClusterBom(ctx context.Context) (*bom.Result, error) {
 	return c.getClusterBomInfo(components, nodesInfo)
 }
 
-func extractTag(imageName, digest string) string {
-	if !strings.Contains(imageName, ":") {
-		return containerimage.DefaultTag
-	}
-	parts := strings.Split(imageName, ":")
-	return strings.TrimSuffix(parts[len(parts)-1], "@"+digest)
-}
-
 func extractDigest(imageId string) string {
 	if strings.Contains(imageId, "@") {
 		imageId = strings.Split(imageId, "@")[1]
@@ -515,11 +507,6 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 	}
 
 	version := imageRef.Identifier()
-	switch digestRef := imageRef.(type) {
-	case containerimage.Digest:
-		version = extractTag(imageName, digestRef.DigestStr())
-	}
-
 	return bom.Container{
 		Repository: repoName,
 		Registry:   registryName,

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -956,9 +956,12 @@ func trimString(version string, trimValues []string) string {
 }
 
 func getImageID(image string) string {
+	if strings.HasPrefix(image, digest.Canonical.String()+":") {
+		return image
+	}
 	imageParts := strings.Split(image, "@")
-	if len(imageParts) > 1 && strings.HasPrefix(imageParts[1], "sha256") {
+	if len(imageParts) > 1 && strings.HasPrefix(imageParts[1], digest.Canonical.String()+":") {
 		return imageParts[1]
 	}
-	return image
+	return ""
 }

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -603,11 +603,11 @@ func getImageIDsByStatuses(pod corev1.Pod) []string {
 
 	statusMap := make(map[string]string)
 	for _, status := range pod.Status.ContainerStatuses {
-		statusMap[status.Name] = status.ImageID
+		statusMap[status.Image] = status.ImageID
 	}
 
 	for i, container := range pod.Spec.Containers {
-		if id, ok := statusMap[container.Name]; ok {
+		if id, ok := statusMap[container.Image]; ok {
 			ids[i] = getImageID(id)
 			continue
 		}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -488,7 +488,7 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 	}
 	imageRef, err := utils.ParseReference(imageName)
 	if err != nil {
-		return bom.Container{}, fmt.Errorf("unable to parse imageRef name reference %q: %v", imageName, err)
+		return bom.Container{}, fmt.Errorf("unable to parse image name %q: %v", imageName, err)
 	}
 	// parse imageId to get the digest
 	hex := extractDigest(imageId)

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -491,9 +491,9 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 		return bom.Container{}, fmt.Errorf("unable to parse image name %q: %v", imageName, err)
 	}
 	// parse imageId to get the digest
-	hex := extractDigest(imageId)
+	imageDigest := extractDigest(imageId)
 	// skip non sha256 digests
-	if len(hex) != digest.Canonical.Size()*2 {
+	if len(imageDigest) != digest.Canonical.Size()*2 {
 		return bom.Container{}, fmt.Errorf("unable to parse digest %q for %q", imageId, imageName)
 	}
 
@@ -511,7 +511,7 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 		Repository: repoName,
 		Registry:   registryName,
 		ID:         fmt.Sprintf("%s:%s", repoName, version),
-		Digest:     hex,
+		Digest:     imageDigest,
 		Version:    version,
 	}, nil
 }

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -502,7 +502,7 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 	hex := extractDigest(imageId)
 	// skip non sha256 digests
 	if len(hex) != digest.Canonical.Size()*2 {
-		return bom.Container{}, fmt.Errorf("unable to parse digest %q for %q", imageName, imageName)
+		return bom.Container{}, fmt.Errorf("unable to parse digest %q for %q", imageId, imageName)
 	}
 
 	repoName := imageRef.Context().RepositoryStr()

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -472,13 +472,17 @@ func (c *cluster) CreateClusterBom(ctx context.Context) (*bom.Result, error) {
 	return c.getClusterBomInfo(components, nodesInfo)
 }
 
+func extractVersion(image containerimage.Digest) string {
+	return strings.TrimPrefix(strings.TrimSuffix(strings.TrimPrefix(image.String(), image.Context().Name()), "@"+image.DigestStr()), ":")
+}
+
 func GetContainer(hex string, imageName containerimage.Reference) (bom.Container, error) {
 	repoName := imageName.Context().RepositoryStr()
 	registryName := imageName.Context().RegistryStr()
 	version := imageName.Identifier()
-	switch t := imageName.(type) {
+	switch image := imageName.(type) {
 	case containerimage.Digest:
-		version = strings.TrimPrefix(strings.TrimSuffix(strings.TrimPrefix(imageName.String(), imageName.Context().Name()), "@"+t.DigestStr()), ":")
+		version = extractVersion(image)
 	}
 
 	return bom.Container{

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -579,6 +579,7 @@ func PodInfo(pod corev1.Pod, labelSelector string) (*bom.Component, error) {
 			continue
 		}
 		hex := imageRef.Context().Digest(imageRef.Identifier()).DigestStr()
+		hex = strings.TrimPrefix(hex, string(digest.Canonical)+":")
 		// skip non sha256 digests
 		if len(hex) != digest.Canonical.Size()*2 {
 			continue

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -378,6 +378,18 @@ func TestGetContainer(t *testing.T) {
 			},
 		},
 		{
+			name:    "use local registry with custom port",
+			image:   "myregistry.com:5000/project/image:v1.0.0",
+			imageId: "myregistry.com:5000/project/image@sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			container: bom.Container{
+				ID:         "project/image:v1.0.0",
+				Version:    "v1.0.0",
+				Repository: "project/image",
+				Registry:   "myregistry.com:5000",
+				Digest:     "1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",
+			},
+		},
+		{
 			name:    "imageID is digest",
 			image:   "gcr.io/project/image:v1.0.0",
 			imageId: "sha256:1420cefd4b20014b3361951c22593de6e9a2476bbbadd1759464eab5bfc0d34f",

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -336,6 +336,11 @@ func TestGetImageId(t *testing.T) {
 			input:   "docker.io/library/import-2023-05-12@sha256:346b96f3a1892101fc63ca880036b4f72562961984d208df71c299041c3f0e51",
 			imageId: "sha256:346b96f3a1892101fc63ca880036b4f72562961984d208df71c299041c3f0e51",
 		},
+		{
+			name:    "parse email",
+			input:   "docker.io/library/import-2023-05-12@baddigest",
+			imageId: "",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -248,6 +248,121 @@ func TestPodInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:          "multi-image pod - strict mapping",
+			labelSelector: "app.kubernetes.io/component=controller",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-nginx-controller-8547bfc86c-dr7lq",
+					Namespace: "ingress-nginx",
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "controller",
+						"app.kubernetes.io/name":      "ingress-nginx",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "registry.k8s.io/ingress-nginx/controller:v1.11.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						},
+						{
+							Image: "registry.k8s.io/ingress-nginx/controller:v1.21.0",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Image:   "registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+							ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						},
+						{
+							Image:   "registry.k8s.io/ingress-nginx/controller:v1.21.0",
+							ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+						},
+					},
+				},
+			},
+			want: &bom.Component{
+				Namespace: "ingress-nginx",
+				Name:      "k8s.io/ingress-nginx",
+				Version:   "1.11.0",
+				Properties: map[string]string{
+					"Name": "ingress-nginx-controller-8547bfc86c-dr7lq",
+					"Type": "controller",
+				},
+				Containers: []bom.Container{
+					{
+						ID:         "ingress-nginx/controller:v1.11.0",
+						Version:    "v1.11.0",
+						Repository: "ingress-nginx/controller",
+						Registry:   "registry.k8s.io",
+						Digest:     "a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+					},
+					{
+						ID:         "ingress-nginx/controller:v1.21.0",
+						Version:    "v1.21.0",
+						Repository: "ingress-nginx/controller",
+						Registry:   "registry.k8s.io",
+						Digest:     "a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+					},
+				},
+			},
+		},
+		{
+			Name:          "multi-image pod - digest from image",
+			labelSelector: "app.kubernetes.io/component=controller",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-nginx-controller-8547bfc86c-dr7lq",
+					Namespace: "ingress-nginx",
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "controller",
+						"app.kubernetes.io/name":      "ingress-nginx",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "registry.k8s.io/ingress-nginx/controller:v1.11.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						},
+						{
+							Image: "registry.k8s.io/ingress-nginx/controller:v1.21.0",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Image:   "registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+							ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						},
+						{
+							Image:   "sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+							ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+						},
+					},
+				},
+			},
+			want: &bom.Component{
+				Namespace: "ingress-nginx",
+				Name:      "k8s.io/ingress-nginx",
+				Version:   "1.11.0",
+				Properties: map[string]string{
+					"Name": "ingress-nginx-controller-8547bfc86c-dr7lq",
+					"Type": "controller",
+				},
+				Containers: []bom.Container{
+					{
+						ID:         "ingress-nginx/controller:v1.11.0",
+						Version:    "v1.11.0",
+						Repository: "ingress-nginx/controller",
+						Registry:   "registry.k8s.io",
+						Digest:     "a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -214,8 +214,8 @@ func TestPodInfo(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{{
-						Image:   "sha256:560a9fa980f663e5b71a6ca2df40f504fa577d0e38f9d0aed06c2a8eff53cb50",
-						ImageID: "registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						Image:   "registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
 					},
 					},
 				},
@@ -228,7 +228,15 @@ func TestPodInfo(t *testing.T) {
 					"Name": "ingress-nginx-controller-8547bfc86c-dr7lq",
 					"Type": "controller",
 				},
-				Containers: []bom.Container{},
+				Containers: []bom.Container{
+					{
+						ID:         "ingress-nginx/controller:sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						Version:    "sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						Repository: "ingress-nginx/controller",
+						Registry:   "registry.k8s.io",
+						Digest:     "a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -161,6 +161,42 @@ func TestPodInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:          "etcd pod with image in another format",
+			labelSelector: "component",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd-minikube",
+					Namespace: "kube-system",
+					Labels:    map[string]string{"component": "etcd"},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Image:   "registry.k8s.io/etcd:3.5.15-0",
+						ImageID: "docker-pullable://registry.k8s.io/etcd@sha256:a6dc63e6e8cfa0307d7851762fa6b629afb18f28d8aa3fab5a6e91b4af60026a",
+					},
+					},
+				},
+			},
+			want: &bom.Component{
+				Namespace: "kube-system",
+				Name:      "go.etcd.io/etcd/v3",
+				Version:   "3.5.15-0",
+				Properties: map[string]string{
+					"Name": "etcd-minikube",
+					"Type": "controlPlane",
+				},
+				Containers: []bom.Container{
+					{
+						ID:         "etcd:3.5.15-0",
+						Version:    "3.5.15-0",
+						Repository: "etcd",
+						Registry:   "registry.k8s.io",
+						Digest:     "a6dc63e6e8cfa0307d7851762fa6b629afb18f28d8aa3fab5a6e91b4af60026a",
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -327,6 +327,68 @@ func TestPodInfo(t *testing.T) {
 							Image: "registry.k8s.io/ingress-nginx/controller:v1.11.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
 						},
 						{
+							Image: "registry.k8s.io/ingress-nginx/controller:v1.21.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Image:   "registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+							ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						},
+						{
+							Image:   "sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+							ImageID: "docker-pullable://registry.k8s.io/ingress-nginx/controller@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+						},
+					},
+				},
+			},
+			want: &bom.Component{
+				Namespace: "ingress-nginx",
+				Name:      "k8s.io/ingress-nginx",
+				Version:   "1.11.0",
+				Properties: map[string]string{
+					"Name": "ingress-nginx-controller-8547bfc86c-dr7lq",
+					"Type": "controller",
+				},
+				Containers: []bom.Container{
+					{
+						ID:         "ingress-nginx/controller:v1.11.0",
+						Version:    "v1.11.0",
+						Repository: "ingress-nginx/controller",
+						Registry:   "registry.k8s.io",
+						Digest:     "a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+					},
+					{
+						ID:         "ingress-nginx/controller:v1.21.0",
+						Version:    "v1.21.0",
+						Repository: "ingress-nginx/controller",
+						Registry:   "registry.k8s.io",
+						Digest:     "a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb51",
+					},
+				},
+			},
+		},
+
+		{
+			Name:          "multi-image pod - skip unmapped image",
+			labelSelector: "app.kubernetes.io/component=controller",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-nginx-controller-8547bfc86c-dr7lq",
+					Namespace: "ingress-nginx",
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "controller",
+						"app.kubernetes.io/name":      "ingress-nginx",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "registry.k8s.io/ingress-nginx/controller:v1.11.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+						},
+						{
 							Image: "registry.k8s.io/ingress-nginx/controller:v1.21.0",
 						},
 					},

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -317,24 +317,24 @@ func TestGetImageId(t *testing.T) {
 		imageId string
 	}{
 		{
-			"sha256 (ex. KinD)",
-			"sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
-			"sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
+			name:    "sha256 (ex. KinD)",
+			input:   "sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
+			imageId: "sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
 		},
 		{
-			"docker pullable (ex. Minikube)",
-			"docker-pullable://registry.k8s.io/kube-apiserver@sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
-			"sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
+			name:    "docker pullable (ex. Minikube)",
+			input:   "docker-pullable://registry.k8s.io/kube-apiserver@sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
+			imageId: "sha256:a6daed8429c54f0008910fc4ecc17aefa1dfcd7cc2ff0089570854d4f95213ed",
 		},
 		{
-			"image name",
-			"registry.k8s.io/ingress-nginx/controller:v1.11.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
-			"sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+			name:    "image name",
+			input:   "registry.k8s.io/ingress-nginx/controller:v1.11.0@sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
+			imageId: "sha256:a886e56d532d1388c77c8340261149d974370edca1093af4c97a96fb1467cb39",
 		},
 		{
-			"id with data",
-			"docker.io/library/import-2023-05-12@sha256:346b96f3a1892101fc63ca880036b4f72562961984d208df71c299041c3f0e51",
-			"sha256:346b96f3a1892101fc63ca880036b4f72562961984d208df71c299041c3f0e51",
+			name:    "id with data",
+			input:   "docker.io/library/import-2023-05-12@sha256:346b96f3a1892101fc63ca880036b4f72562961984d208df71c299041c3f0e51",
+			imageId: "sha256:346b96f3a1892101fc63ca880036b4f72562961984d208df71c299041c3f0e51",
 		},
 	}
 
@@ -344,5 +344,4 @@ func TestGetImageId(t *testing.T) {
 			assert.Equal(t, got, test.imageId)
 		})
 	}
-
 }


### PR DESCRIPTION
## Description
This PR fixes:

1. Enhanced Image Data Source
Previously, image information was retrieved only from `pod.Status.ContainerStatuses`, which does not always contain complete data.
Also `pod.status.containerStatuses` sometimes displayed image name incorrectly when image has multiple tags on the node: https://github.com/kubernetes/kubernetes/issues/74081
Now, both `pod.Spec` and `pod.Status` are used to ensure accurate image retrieval.

2. Fixed Parsing of Tags and Digests
When an image contained both a tag and a digest, the parser incorrectly extracted the digest instead of the version. 
the same issue was fixed in Trivy-operator: https://github.com/aquasecurity/trivy-operator/pull/2418/
We implemented it ourselves because it's a known issue in go-containerregistry, this one is closed as `not planned`: https://github.com/google/go-containerregistry/issues/1768, but there is a new issue https://github.com/google/go-containerregistry/issues/2069
This has been fixed to correctly parse and extract the version from the image.

## Reproduction steps
Prepare
```sh
$ kind delete cluster && kind create cluster --image kindest/node:v1.27.1
$ kubectl wait --for=condition=Ready --all nodes
```
Before:
```sh
$ k8s --report summary --scanners vuln --skip-images
...
Infra Assessment
┌───────────┬─────────────────────────┬───────────────────┐
│ Namespace │        Resource         │  Vulnerabilities  │
│           │                         ├───┬───┬───┬───┬───┤
│           │                         │ C │ H │ M │ L │ U │
├───────────┼─────────────────────────┼───┼───┼───┼───┼───┤
│           │ Node/kind-control-plane │   │   │   │   │ 7 │
└───────────┴─────────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```
After
```sh
Infra Assessment
┌─────────────┬─────────────────────────────────────────┬───────────────────┐
│  Namespace  │                Resource                 │  Vulnerabilities  │
│             │                                         ├───┬───┬───┬───┬───┤
│             │                                         │ C │ H │ M │ L │ U │
├─────────────┼─────────────────────────────────────────┼───┼───┼───┼───┼───┤
│ kube-system │ ControlPlaneComponents/k8s.io/apiserver │   │   │ 2 │ 1 │   │
│             │ Node/kind-control-plane                 │   │ 3 │ 3 │ 1 │   │
└─────────────┴─────────────────────────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```

more details https://github.com/aquasecurity/trivy/issues/8358

## References
* https://kubernetes.io/docs/concepts/containers/images/
* https://github.com/kubernetes/kubernetes/blob/eebc897e4fd8bf26a69d322c8dbcdf4da475934e/pkg/apis/core/types.go#L2744-L2747