### PR TITLE
fix: remove using `last-applied-configuration`

### DIFF
--- a/pkg/trivyk8s/trivyk8s.go
+++ b/pkg/trivyk8s/trivyk8s.go
@@ -278,18 +278,11 @@ func (c *client) ListSpecificArtifacts(ctx context.Context) ([]*artifacts.Artifa
 				continue
 			}
 
-			lastAppliedResource := resource
-			if jsonManifest, ok := resource.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]; ok { // required for outdated-api when k8s convert resources
-				err := json.Unmarshal([]byte(jsonManifest), &lastAppliedResource)
-				if err != nil {
-					continue
-				}
-			}
-			auths, err := c.cluster.AuthByResource(lastAppliedResource)
+			auths, err := c.cluster.AuthByResource(resource)
 			if err != nil {
 				return nil, fmt.Errorf("failed getting auth for gvr: %v - %w", gvr, err)
 			}
-			artifact, err := artifacts.FromResource(lastAppliedResource, auths)
+			artifact, err := artifacts.FromResource(resource, auths)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/trivyk8s/trivyk8s_test.go
+++ b/pkg/trivyk8s/trivyk8s_test.go
@@ -410,7 +410,7 @@ func TestListSpecificArtifacts(t *testing.T) {
 			},
 		},
 		{
-			name:      "use last-applied-config",
+			name:      "ignore last-applied-config",
 			namespace: "default",
 			resources: []string{filepath.Join("testdata", "single-pod.yaml")},
 			kinds:     []string{"pod"},
@@ -423,7 +423,7 @@ func TestListSpecificArtifacts(t *testing.T) {
 					Kind:        "Pod",
 					Labels:      nil,
 					Name:        "nginx-pod",
-					Images:      []string{"nginx:1.14.1"},
+					Images:      []string{"nginx:1.27.4"},
 					Credentials: []docker.Auth{},
 				},
 			},


### PR DESCRIPTION
## Description
This PR removes the logic for scanning Kubernetes resources via the `last-applied-configuration` annotation.

As of Kubernetes v1.25, resources that previously relied on this annotation have been removed, making this scanning method unuseful.

This PR is created in favor of discussion in comments: https://github.com/aquasecurity/trivy/pull/8456