### PR TITLE
chore(deps): bump golangci-lint to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Verify Go code
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
           args: --verbose --timeout=5m
-          version: v1.64.2
+          version: v2.1.5
           skip-pkg-cache: true
           skip-build-cache: true
       - name: Verify YAML code

--- a/pkg/jobs/logs.go
+++ b/pkg/jobs/logs.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var podControlledByJobNotFoundErr = errors.New("pod for job not found")
+var errPodControlledByJobNotFound = errors.New("pod for job not found")
 
 // LogsReader responsible for collecting container status and logs
 type LogsReader interface {
@@ -38,7 +38,7 @@ func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batc
 		return nil, fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, err)
 	}
 	if pod == nil {
-		return nil, fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, podControlledByJobNotFoundErr)
+		return nil, fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, errPodControlledByJobNotFound)
 	}
 
 	return r.clientset.CoreV1().Pods(pod.Namespace).
@@ -103,5 +103,5 @@ func GetTerminatedContainersStatusesByPod(pod *corev1.Pod) map[string]*corev1.Co
 }
 
 func IsPodControlledByJobNotFound(err error) bool {
-	return errors.Is(err, podControlledByJobNotFoundErr)
+	return errors.Is(err, errPodControlledByJobNotFound)
 }

--- a/pkg/jobs/util.go
+++ b/pkg/jobs/util.go
@@ -32,7 +32,7 @@ func deepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 		DisableMethods: true,
 		SpewKeys:       true,
 	}
-	printer.Fprintf(hasher, "%#v", objectToWrite)
+	_, _ = printer.Fprintf(hasher, "%#v", objectToWrite)
 }
 
 func compressAndEncode(data []byte) (string, error) {
@@ -46,6 +46,6 @@ func compressAndEncode(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	w.Close()
+	_ = w.Close()
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }

--- a/pkg/k8s/docker/config.go
+++ b/pkg/k8s/docker/config.go
@@ -129,7 +129,7 @@ func GetServerFromImageRef(imageRef string) (string, error) {
 // For the sake of comparison we need to normalize the registry identifier.
 func GetServerFromDockerAuthKey(key string) (string, error) {
 
-	if !(strings.HasPrefix(key, "http://") || strings.HasPrefix(key, "https://")) {
+	if !strings.HasPrefix(key, "http://") && !strings.HasPrefix(key, "https://") {
 		key = fmt.Sprintf("https://%s", key)
 	}
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -10,8 +10,6 @@ import (
 	ms "github.com/mitchellh/mapstructure"
 	"github.com/opencontainers/go-digest"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8sapierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -519,7 +517,7 @@ func GetContainer(imageName, imageId string) (bom.Container, error) {
 func (c *cluster) CollectNodes(components []bom.Component) ([]bom.NodeInfo, error) {
 	nodes, err := c.clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) || errors.IsForbidden(err) {
+		if k8sapierror.IsNotFound(err) || k8sapierror.IsForbidden(err) {
 			slog.Error("Unable to list node resources", "error", err)
 			return []bom.NodeInfo{}, nil
 		}
@@ -545,7 +543,7 @@ func (c *cluster) CollectNodes(components []bom.Component) ([]bom.NodeInfo, erro
 	return nodesInfo, nil
 }
 
-func NodeInfo(node v1.Node) bom.NodeInfo {
+func NodeInfo(node corev1.Node) bom.NodeInfo {
 	nodeRole := "worker"
 	if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
 		nodeRole = "master"
@@ -560,7 +558,7 @@ func NodeInfo(node v1.Node) bom.NodeInfo {
 		OsImage:                 node.Status.NodeInfo.OSImage,
 		Properties: map[string]string{
 			"NodeRole":        nodeRole,
-			"HostName":        node.ObjectMeta.Name,
+			"HostName":        node.Name,
 			"KernelVersion":   node.Status.NodeInfo.KernelVersion,
 			"OperatingSystem": node.Status.NodeInfo.OperatingSystem,
 			"Architecture":    node.Status.NodeInfo.Architecture,

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aquasecurity/trivy-kubernetes/pkg/bom"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -438,13 +437,13 @@ func TestPodInfo(t *testing.T) {
 func TestNodeInfo(t *testing.T) {
 	tests := []struct {
 		Name          string
-		node          v1.Node
+		node          corev1.Node
 		labelSelector string
 		want          bom.NodeInfo
 	}{
 		{
 			Name: "node info ",
-			node: v1.Node{
+			node: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Labels: map[string]string{
@@ -452,8 +451,8 @@ func TestNodeInfo(t *testing.T) {
 						"node-role.kubernetes.io/master": "",
 					},
 				},
-				Status: v1.NodeStatus{
-					NodeInfo: v1.NodeSystemInfo{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
 						Architecture:            "amd64",
 						ContainerRuntimeVersion: "containerd://1.5.2",
 						KubeletVersion:          "1.21.1",


### PR DESCRIPTION
This PR bumps up golangci-lint to version v2 and github action to support it.
It made in favor of Trivy https://github.com/aquasecurity/trivy/pull/8766